### PR TITLE
Add dependabot scanning to repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 15
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 15
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: tuesday
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 15


### PR DESCRIPTION
## Description of change

Adds dependabot to the repo to ensure dependencies are kept upto date

## Link to relevant ticket

N/A

## Notes for reviewer

This mirrors the config for [Court Data UI](https://github.com/ministryofjustice/laa-court-data-ui/blob/main/.github/dependabot.yml)

## Screenshots of changes (if applicable)

N/A

### Before changes:

N/A

### After changes:

N/A

## How to manually test the feature

This will kick off post merge
