### PR TITLE
[Crm457 146] hide workflow item type

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,7 +131,9 @@ Naming/PredicateName:
 
 # TODO: adjust these values towards the rubocop defaults
 RSpec/MultipleMemoizedHelpers:
-  Max: 15
+  Max: 12
+  Exclude:
+    - spec/steps/work_items/add/form_spec.rb
 
 RSpec/MultipleExpectations:
   Max: 7

--- a/app/forms/steps/letters_calls_form.rb
+++ b/app/forms/steps/letters_calls_form.rb
@@ -13,8 +13,13 @@ module Steps
     validates :letters_calls_uplift, presence: true,
 numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, if: :apply_uplift
 
+    def allow_uplift?
+      application.reasons_for_claim.include?(ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s)
+    end
+
     def apply_uplift
-      @apply_uplift.nil? ? letters_calls_uplift.present? : @apply_uplift == 'true'
+      allow_uplift? &&
+        (@apply_uplift.nil? ? letters_calls_uplift.present? : @apply_uplift == 'true')
     end
 
     def letters_total

--- a/app/forms/steps/work_item_form.rb
+++ b/app/forms/steps/work_item_form.rb
@@ -35,8 +35,8 @@ module Steps
     end
 
     def work_types_with_pricing
-      WorkTypes.values.map do |value|
-        [value, pricing[value.to_s]]
+      WorkTypes.values.filter_map do |work_type|
+        [work_type, pricing[work_type.to_s]] if work_type.display?(application)
       end
     end
 

--- a/app/forms/steps/work_item_form.rb
+++ b/app/forms/steps/work_item_form.rb
@@ -25,8 +25,13 @@ module Steps
             numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
             if: :apply_uplift
 
+    def allow_uplift?
+      application.reasons_for_claim.include?(ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s)
+    end
+
     def apply_uplift
-      @apply_uplift.nil? ? uplift.present? : @apply_uplift == 'true'
+      allow_uplift? &&
+        (@apply_uplift.nil? ? uplift.present? : @apply_uplift == 'true')
     end
 
     def pricing

--- a/app/forms/steps/work_item_form.rb
+++ b/app/forms/steps/work_item_form.rb
@@ -12,7 +12,10 @@ module Steps
     attribute :fee_earner, :string
     attribute :uplift, :integer
 
-    validates :work_type, presence: true
+    # TODO: limit this to displayed WorkTypes - this could lead to issues if conditions
+    # are changed as the validation would fail without clearly showing on the summary
+    # page
+    validates :work_type, presence: true, inclusion: { in: WorkTypes.values }
     validates :hours, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
     validates :minutes, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
     validates :completed_on, presence: true,

--- a/app/value_objects/work_types.rb
+++ b/app/value_objects/work_types.rb
@@ -1,10 +1,27 @@
 class WorkTypes < ValueObject
+  def initialize(raw_value, &block)
+    @block = block
+    super(raw_value)
+  end
+
+  def display?(application)
+    return true if @block.nil?
+
+    @block.call(application)
+  end
+
   VALUES = [
+    ATTENDANCE_WITH_COUNSEL = new(:attendance_with_counsel) do |application|
+      application.assigned_counsel == YesNoAnswer::YES.to_s
+    end,
+    ATTENDANCE_WITHOUT_COUNSEL = new(:attendance_without_counsel),
     PREPARATION = new(:preparation),
     ADVOCACY = new(:advocacy),
-    ATTENDANCE_WITH_COUNSEL = new(:attendance_with_counsel),
-    ATTENDANCE_WITHOUT_COUNSEL = new(:attendance_without_counsel),
-    TRAVEL = new(:travel),
-    WAITING = new(:waiting),
+    TRAVEL = new(:travel) do |application|
+      application.in_area == YesNoAnswer::NO.to_s
+    end,
+    WAITING = new(:waiting) do |application|
+      application.in_area == YesNoAnswer::NO.to_s
+    end,
   ].freeze
 end

--- a/app/views/steps/letters_calls/edit.html.erb
+++ b/app/views/steps/letters_calls/edit.html.erb
@@ -11,8 +11,10 @@
       <%= f.govuk_number_field :letters, min: 1, step: 1, width: 3, data:{rate_letters: @form_object.pricing.letters} %>
       <%= f.govuk_number_field :calls, min: 1, step: 1, width: 3, data:{rate_phone_calls: @form_object.pricing.calls} %>
       <%= f.govuk_check_boxes_fieldset :apply_uplift, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :apply_uplift, 'true', 'false', multiple: false do %>
-          <%= f.govuk_number_field :letters_calls_uplift, min: 1, step: 1, max: 100, width: 3, suffix_text: '%' %>
+        <% if @form_object.allow_uplift? %>
+          <%= f.govuk_check_box :apply_uplift, 'true', 'false', multiple: false do %>
+            <%= f.govuk_number_field :letters_calls_uplift, min: 1, step: 1, max: 100, width: 3, suffix_text: '%' %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/app/views/steps/work_item/edit.html.erb
+++ b/app/views/steps/work_item/edit.html.erb
@@ -19,9 +19,11 @@
       <%= f.govuk_date_field :completed_on, maxlength_enabled: true, legend: { size: 's' } %>
       <%= f.govuk_text_field :fee_earner, width: 3 %>
 
-      <%= f.govuk_check_boxes_fieldset :apply_uplift, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :apply_uplift, 'true', 'false', multiple: false do %>
-          <%= f.govuk_number_field :uplift, placeholder: 0, min: 1, step: 1, max: 100, width: 3, suffix_text: '%' %>
+      <% if @form_object.allow_uplift? %>
+        <%= f.govuk_check_boxes_fieldset :apply_uplift, multiple: false, legend: nil do %>
+          <%= f.govuk_check_box :apply_uplift, 'true', 'false', multiple: false do %>
+            <%= f.govuk_number_field :uplift, placeholder: 0, min: 1, step: 1, max: 100, width: 3, suffix_text: '%' %>
+          <% end %>
         <% end %>
       <% end %>
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,4 +35,7 @@ RSpec.configure do |config|
 
   # Use the faster rack test by default for system specs
   config.before(:each, type: :system) { driven_by :rack_test }
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
 end

--- a/spec/steps/letters_calls/form_spec.rb
+++ b/spec/steps/letters_calls/form_spec.rb
@@ -13,12 +13,13 @@ RSpec.describe Steps::LettersCallsForm do
     }
   end
 
-  let(:application) { instance_double(Claim, update!: true, date: date) }
+  let(:application) { instance_double(Claim, update!: true, date: date, reasons_for_claim: reasons_for_claim) }
   let(:letters) { 1 }
   let(:calls) { 1 }
   let(:apply_uplift) { 'true' }
   let(:letters_calls_uplift) { 0 }
   let(:date) { nil }
+  let(:reasons_for_claim) { [ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s] }
 
   describe '#validations' do
     describe '#letters' do
@@ -154,31 +155,51 @@ RSpec.describe Steps::LettersCallsForm do
     end
   end
 
-  describe '#apply_uplift' do
-    context 'when set to nil - not set' do
-      let(:apply_uplift) { nil }
+  describe '#allow_uplift?' do
+    context 'when reasons_for_claim contains ENHANCED_RATES_CLAIMED' do
+      it { expect(subject).to be_allow_uplift }
+    end
 
-      context 'and letters_calls_uplift is not nil' do
-        let(:letters_calls_uplift) { 10 }
+    context 'when reasons_for_claim does not contain ENHANCED_RATES_CLAIMED' do
+      let(:reasons_for_claim) { ['other'] }
+
+      it { expect(subject).not_to be_allow_uplift }
+    end
+  end
+
+  describe '#apply_uplift' do
+    context 'when reasons_for_claim contains ENHANCED_RATES_CLAIMED' do
+      context 'when set to nil - not set' do
+        let(:apply_uplift) { nil }
+
+        context 'and letters_calls_uplift is not nil' do
+          let(:letters_calls_uplift) { 10 }
+
+          it { expect(subject.apply_uplift).to be_truthy }
+        end
+
+        context 'and letters_calls_uplift is nil' do
+          let(:letters_calls_uplift) { nil }
+
+          it { expect(subject.apply_uplift).to be_falsey }
+        end
+      end
+
+      context 'when set to "true"' do
+        let(:apply_uplift) { 'true' }
 
         it { expect(subject.apply_uplift).to be_truthy }
       end
 
-      context 'and letters_calls_uplift is nil' do
-        let(:letters_calls_uplift) { nil }
+      context 'when set to "false"' do
+        let(:apply_uplift) { 'false' }
 
         it { expect(subject.apply_uplift).to be_falsey }
       end
     end
 
-    context 'when set to "true"' do
-      let(:apply_uplift) { 'true' }
-
-      it { expect(subject.apply_uplift).to be_truthy }
-    end
-
-    context 'when set to "false"' do
-      let(:apply_uplift) { 'false' }
+    context 'when reasons_for_claim does not contain ENHANCED_RATES_CLAIMED' do
+      let(:reasons_for_claim) { ['other'] }
 
       it { expect(subject.apply_uplift).to be_falsey }
     end

--- a/spec/steps/letters_calls/integration_spec.rb
+++ b/spec/steps/letters_calls/integration_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe 'User can fill in claim type details', type: :system do
   end
 
   it 'can do green path' do
+    claim.update!(reasons_for_claim: [ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s])
+
     visit edit_steps_letters_calls_path(claim.id)
 
     fill_in 'Number of letters', with: 1

--- a/spec/steps/work_items/add/form_spec.rb
+++ b/spec/steps/work_items/add/form_spec.rb
@@ -308,7 +308,9 @@ RSpec.describe Steps::WorkItemForm do
   end
 
   describe 'save!' do
-    let(:application) { Claim.create!(office_code: 'AAA', reasons_for_claim: [ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s]) }
+    let(:application) do
+      Claim.create!(office_code: 'AAA', reasons_for_claim: [ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s])
+    end
     let(:record) { WorkItem.create!(uplift: 40, claim: application) }
 
     context 'when uplift exists in DB but apply_uplift is false in attributes' do

--- a/spec/steps/work_items/add/form_spec.rb
+++ b/spec/steps/work_items/add/form_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe Steps::WorkItemForm do
     }
   end
 
-  let(:application) { instance_double(Claim, work_items: work_items, update!: true, date: date) }
+  let(:application) do
+    instance_double(Claim, work_items: work_items, update!: true, date: date, assigned_counsel: assigned_counsel,
+   in_area: in_area)
+  end
   let(:work_items) { [double(:record), record] }
   let(:id) { record.id }
   let(:date) { Date.new(2023, 1, 1) }
@@ -30,6 +33,8 @@ RSpec.describe Steps::WorkItemForm do
   let(:fee_earner) { 'JBJ' }
   let(:apply_uplift) { 'true' }
   let(:uplift) { 10 }
+  let(:assigned_counsel) { 'yes' }
+  let(:in_area) { 'no' }
 
   describe '#validations' do
     context 'require fields' do
@@ -203,26 +208,80 @@ RSpec.describe Steps::WorkItemForm do
 
       it 'uses the old prices' do
         expect(subject.work_types_with_pricing).to eq([
-                                                        [WorkTypes::PREPARATION, 45.35],
-                                                        [WorkTypes::ADVOCACY, 56.89],
                                                         [WorkTypes::ATTENDANCE_WITH_COUNSEL, 31.03],
                                                         [WorkTypes::ATTENDANCE_WITHOUT_COUNSEL, 31.03],
+                                                        [WorkTypes::PREPARATION, 45.35],
+                                                        [WorkTypes::ADVOCACY, 56.89],
                                                         [WorkTypes::TRAVEL, 24.0],
                                                         [WorkTypes::WAITING, 24.0],
                                                       ])
+      end
+
+      context 'when assigned_councel is no' do
+        let(:assigned_counsel) { 'no' }
+
+        it 'does not include ATTENDANCE_WITH_COUNSEL' do
+          expect(subject.work_types_with_pricing).to eq([
+                                                          [WorkTypes::ATTENDANCE_WITHOUT_COUNSEL, 31.03],
+                                                          [WorkTypes::PREPARATION, 45.35],
+                                                          [WorkTypes::ADVOCACY, 56.89],
+                                                          [WorkTypes::TRAVEL, 24.0],
+                                                          [WorkTypes::WAITING, 24.0],
+                                                        ])
+        end
+      end
+
+      context 'when in_area is yes' do
+        let(:in_area) { 'yes' }
+
+        it 'does not include TRAVEL or WAITING' do
+          expect(subject.work_types_with_pricing).to eq([
+                                                          [WorkTypes::ATTENDANCE_WITH_COUNSEL, 31.03],
+                                                          [WorkTypes::ATTENDANCE_WITHOUT_COUNSEL, 31.03],
+                                                          [WorkTypes::PREPARATION, 45.35],
+                                                          [WorkTypes::ADVOCACY, 56.89],
+                                                        ])
+        end
       end
     end
 
     context 'when application date is after CLAIR' do
       it 'uses the new prices' do
         expect(subject.work_types_with_pricing).to eq([
-                                                        [WorkTypes::PREPARATION, 52.15],
-                                                        [WorkTypes::ADVOCACY, 65.42],
                                                         [WorkTypes::ATTENDANCE_WITH_COUNSEL, 35.68],
                                                         [WorkTypes::ATTENDANCE_WITHOUT_COUNSEL, 35.68],
+                                                        [WorkTypes::PREPARATION, 52.15],
+                                                        [WorkTypes::ADVOCACY, 65.42],
                                                         [WorkTypes::TRAVEL, 27.6],
                                                         [WorkTypes::WAITING, 27.6],
                                                       ])
+      end
+
+      context 'when assigned_councel is no' do
+        let(:assigned_counsel) { 'no' }
+
+        it 'does not include ATTENDANCE_WITH_COUNSEL' do
+          expect(subject.work_types_with_pricing).to eq([
+                                                          [WorkTypes::ATTENDANCE_WITHOUT_COUNSEL, 35.68],
+                                                          [WorkTypes::PREPARATION, 52.15],
+                                                          [WorkTypes::ADVOCACY, 65.42],
+                                                          [WorkTypes::TRAVEL, 27.6],
+                                                          [WorkTypes::WAITING, 27.6],
+                                                        ])
+        end
+      end
+
+      context 'when in_area is yes' do
+        let(:in_area) { 'yes' }
+
+        it 'does not include TRAVEL or WAITING' do
+          expect(subject.work_types_with_pricing).to eq([
+                                                          [WorkTypes::ATTENDANCE_WITH_COUNSEL, 35.68],
+                                                          [WorkTypes::ATTENDANCE_WITHOUT_COUNSEL, 35.68],
+                                                          [WorkTypes::PREPARATION, 52.15],
+                                                          [WorkTypes::ADVOCACY, 65.42],
+                                                        ])
+        end
       end
     end
   end

--- a/spec/steps/work_items/integration_spec.rb
+++ b/spec/steps/work_items/integration_spec.rb
@@ -36,6 +36,38 @@ RSpec.describe 'User can manage work items', type: :system do
     )
   end
 
+  it 'can add a work item with uplift' do
+    claim.update!(reasons_for_claim: [ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s])
+
+    visit edit_steps_work_item_path(claim.id)
+
+    choose 'Advocacy'
+
+    fill_in 'Hours', with: 1
+    fill_in 'Minutes', with: 1
+
+    within('.govuk-fieldset', text: 'Completion date') do
+      fill_in 'Day', with: '20'
+      fill_in 'Month', with: '4'
+      fill_in 'Year', with: '2023'
+    end
+
+    fill_in 'Fee earner initials', with: 'JBJ'
+    check 'Apply an uplift to this work'
+    fill_in 'For example, from any percentage from 1 to 100', with: 10
+    click_on 'Save and continue'
+
+    expect(claim.reload.work_items).to contain_exactly(
+      have_attributes(
+        work_type: 'advocacy',
+        time_spent: 61,
+        completed_on: Date.new(2023, 4, 20),
+        fee_earner: 'JBJ',
+        uplift: 10,
+      )
+    )
+  end
+
   it 'can add additional work items' do
     claim.work_items.create(
       work_type: 'apples',

--- a/spec/steps/work_items/integration_spec.rb
+++ b/spec/steps/work_items/integration_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe 'User can manage work items', type: :system do
     expect(claim.reload.work_items).to contain_exactly(
       have_attributes(
         work_type: 'advocacy',
-        time_spent: 61,
+        hours: 1,
+        minutes: 1,
         completed_on: Date.new(2023, 4, 20),
         fee_earner: 'JBJ',
         uplift: 10,

--- a/spec/steps/work_items/integration_spec.rb
+++ b/spec/steps/work_items/integration_spec.rb
@@ -59,8 +59,7 @@ RSpec.describe 'User can manage work items', type: :system do
     expect(claim.reload.work_items).to contain_exactly(
       have_attributes(
         work_type: 'advocacy',
-        hours: 1,
-        minutes: 1,
+        time_spent: 61,
         completed_on: Date.new(2023, 4, 20),
         fee_earner: 'JBJ',
         uplift: 10,


### PR DESCRIPTION
## Description of change
Add conditional criteria for Work Item types and uplift in the various screens

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRM457-146

## Notes for reviewer
This does not stop data corrupt that can occur as a result of modifying flags after work items have been created.
