### PR TITLE
CRM457-97 - Update env var for banner

### DIFF
--- a/kubectl_deploy/deployment.tpl
+++ b/kubectl_deploy/deployment.tpl
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: ubidemo
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-dev-ecr:ce6220626524b8911e4ede31a37ee090a8dbd4f3
+        image: ${ECR_URL}:${IMAGE_TAG}
         ports:
         - containerPort: 5000
         env:

--- a/kubectl_deploy/deployment.tpl
+++ b/kubectl_deploy/deployment.tpl
@@ -14,10 +14,12 @@ spec:
     spec:
       containers:
       - name: ubidemo
-        image: ${ECR_URL}:${IMAGE_TAG}
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-dev-ecr:ce6220626524b8911e4ede31a37ee090a8dbd4f3
         ports:
         - containerPort: 5000
         env:
+          - name: ENV
+            value: Development
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Description of change

Adds ENV to the deployment file and sets it to Development

## Link to relevant ticket

[CRM457-97](https://dsdmoj.atlassian.net/browse/CRM457-97)

## Notes for reviewer

This has been manually deployed to dev for testing

## Screenshots of changes (if applicable)

<img width="1519" alt="Screenshot 2023-06-20 at 20 00 01" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/672128b2-08dd-4c36-ab1b-32808a64f257">

## How to manually test the feature

Banner should be available on navigating to the page


[CRM457-97]: https://dsdmoj.atlassian.net/browse/CRM457-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ