### PR TITLE
[CRM457-167] START PAGE: Iterate the Claim a non-standard mags payment page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app/assets/builds/*
 
 .vscode
 .idea
+.DS_Store

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -22,7 +22,7 @@
                   class: 'govuk-link',
                   role: 'link',
                   target: '_blank'%>
-                  , <%= t('home.section.link.CCCD.content') %>
+                  , <%= t('.section.link.CCCD.content') %>
       </li>
       <li>
       <%= link_to t('.section.link.CWA.name'), "https://portal.legalservices.gov.uk/",

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -1,7 +1,7 @@
 <% title '' %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters">
     <%#= render partial: 'shared/flash_banner' %>
 
     <h1 class="govuk-heading-xl">
@@ -9,26 +9,29 @@
     </h1>
 
     <p class="govuk-body">
-      Use this service to apply for criminal legal aid.
+    <%= t('.instruction') %>
     </p>
 
     <h3 class="govuk-heading-m">
-      Before you start
+      <%= t('.section.title')%>
     </h3>
 
-    <p class="govuk-body">
-      You can only use this service if:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the case is ongoing</li>
-      <li>you know your client's National Insurance number</li>
-      <li>your client does not have a partner</li>
-      <li>your client receives a passporting benefit, including Universal Credit</li>
+    <ul class="govuk-list">
+      <li>
+      <%= link_to t('.section.link.CCCD.name'), "https://claim-crown-court-defence.service.gov.uk/",
+                  class: 'govuk-link',
+                  role: 'link',
+                  target: '_blank'%>
+                  , <%= t('home.section.link.CCCD.content') %>
+      </li>
+      <li>
+      <%= link_to t('.section.link.CWA.name'), "https://portal.legalservices.gov.uk/",
+                  class: 'govuk-link',
+                  role: 'link',
+                  target: '_blank'%>
+                  , <%= t('.section.link.CWA.content') %>
+      </li>
     </ul>
-
-    <p class="govuk-body">
-      Use <%#= link_to 'eForms', Settings.eforms_url %> for all other applications.
-    </p>
 
     <% if Rails.env.development? %>
       <%= link_button nil, provider_saml_omniauth_callback_path, class: 'govuk-button--start govuk-!-margin-top-4' do %>
@@ -37,7 +40,6 @@
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
         </svg>
       <% end %>
-      <br>
       <br>
     <% end %>
 

--- a/config/locales/en/home.yml
+++ b/config/locales/en/home.yml
@@ -1,0 +1,14 @@
+---
+en:
+  home:
+    index:
+      instruction: "You can only use this service to claim a non-standard magistrates' court payment or a breach of injunction payment."
+      section:
+        title: "To claim for something else, go to:"
+        link:
+          CCCD:
+            name: "Claim for Crown Court Defence (CCCD)"
+            content: "if it's a Crown Court case."
+          CWA:
+            name: "Contracted Work and Administration (CWA)"
+            content: "if it’s a standard magistrates’ court case or police station work."


### PR DESCRIPTION
## What
Content changes according to the latest design change.

## Ticket
[START PAGE: Iterate the Claim a non-standard mags payment page](https://dsdmoj.atlassian.net/browse/CRM457-167)
## Why
In the dev environment, this page is currently the same as Crime Apply’s start page. This is incorrect, and needs to be changed to the NSM one.
## Acceptance Criteria

- Build the page as shown in the screenshot

- Comes from clicking “Claim a non-standard mags court payment” link on the LAA online portal AND come from clicking on “back” in the “Your claims” page

- IF user clicks on “Start no” it goes to “Your claims” page

- IF user clicks on “back” button, THEN user lands on LAA online portal landing page

- IF user clicks on “claim for CCCD” THEN user lands on CCCD landing page

- IF user click on “Contracted work and administration” THEN user lands on CWA landing page

**Before**

![685c244a-d9f9-4d3c-ad9b-81fb8bc514be](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/90189839/8879501f-3916-47f6-bd25-3fb7999364c7)

**Now**

![Screenshot 2023-06-23 at 10 17 05](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/90189839/70b9986a-7942-423c-abaf-075accc6820b)
