### PR TITLE
CRM457-242 - Add ping endpoint to application

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -135,7 +135,7 @@ jobs:
             --build-arg APP_BUILD_DATE=${{ env.BUILD_DATE }} \
             --build-arg APP_BUILD_TAG=${{ github.sha }} \
             --build-arg APP_GIT_COMMIT=${{ github.sha }} \
-            --build-arg APP_BRANCH_NAME=${{ github.ref_name }}
+            --build-arg APP_BRANCH_NAME=${{ github.head_ref }} \
             -t app .
 
       - name: Push to ECR

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -133,8 +133,9 @@ jobs:
             --label build.git.branch=${{ github.ref }} \
             --label build.date=${{ env.BUILD_DATE }} \
             --build-arg APP_BUILD_DATE=${{ env.BUILD_DATE }} \
-            --build-arg APP_BUILD_TAG=${{ github.ref }} \
+            --build-arg APP_BUILD_TAG=${{ github.sha }} \
             --build-arg APP_GIT_COMMIT=${{ github.sha }} \
+            --build-arg APP_BRANCH_NAME=${{ github.ref_name }}
             -t app .
 
       - name: Push to ECR

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
 ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
 RUN chmod +r $RDS_COMBINED_CA_BUNDLE
 
+ARG APP_BRANCH_NAME
+ENV APP_BRANCH_NAME ${APP_BRANCH_NAME}
+
 ARG APP_BUILD_DATE
 ENV APP_BUILD_DATE ${APP_BUILD_DATE}
 

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -2,7 +2,7 @@
 
 class HealthcheckController < ApplicationController
   skip_before_action :authenticate_provider!
-  
+
   def ping
     render json: build_args, status: :ok
   end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class HealthcheckController < ApplicationController
+  def ping
+    render json: build_args, status: :ok
+  end
+
+  private
+
+  def build_args
+    {
+      branch_name: ENV.fetch('APP_BRANCH_NAME', nil),
+      build_date: ENV.fetch('APP_BUILD_DATE', nil),
+      build_tag: ENV.fetch('APP_BUILD_TAG', nil),
+      commit_id: ENV.fetch('APP_GIT_COMMIT', nil)
+    }
+  end
+end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HealthcheckController < ApplicationController
+  skip_before_action :authenticate_provider!
+  
   def ping
     render json: build_args, status: :ok
   end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,5 +11,9 @@ if ENV.fetch('SENTRY_DSN', nil).present?
     config.traces_sampler = lambda do |context|
       true
     end
+
+    # Opt in to new Rails error reporting API
+    # https://edgeguides.rubyonrails.org/error_reporting.html
+    config.rails.register_error_subscriber = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ end
 Rails.application.routes.draw do
   extend RouteHelpers
 
+  get :ping, to: 'healthcheck#ping'
+
   # mount this at the route
   mount LaaMultiStepForms::Engine, at: '/'
 

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HealthcheckController do
+  context 'index' do
+
+    before do
+      get :ping
+    end
+
+    it 'renders successfully with 200' do
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'parsed body does not raise exception' do
+      expect { parsed_body }.not_to raise_exception
+    end
+
+    it 'displays correct hash values' do
+      expect(parsed_body.keys).to contain_exactly('branch_name', 'build_date', 'build_tag', 'commit_id')
+    end
+  end
+
+  private
+
+  def parsed_body
+    response.parsed_body.with_indifferent_access
+  end
+end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe HealthcheckController do
   context 'index' do
-
     before do
       get :ping
     end


### PR DESCRIPTION
## Description of change

- Add ping endpoint to application to view app details

## Link to relevant ticket

[CRM457-242](https://dsdmoj.atlassian.net/browse/CRM457-242)

## Notes for reviewer

Implementing to assist with debugging issues

## Screenshots of changes (if applicable)

![Screenshot 2023-07-10 at 16 10 40](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/803e2ecb-4ebc-4068-9aea-9da097a103bc)

### Before changes:

### After changes:

## How to manually test the feature

Navigate to /ping on the application


[CRM457-242]: https://dsdmoj.atlassian.net/browse/CRM457-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ