### PR TITLE
CRM457-265 - Add logstasher to service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'dartsass-rails', '~> 0.5.0'
 gem 'importmap-rails'
 gem 'kaminari'
 gem 'laa_multi_step_forms', path: './gems/laa_multi_step_forms'
+gem "logstasher", "~> 2.1"
 gem 'pg', '~> 1.5'
 gem 'puma', '~> 6.3'
 gem 'rails', '~> 7.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,9 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    logstasher (2.1.5)
+      activesupport (>= 5.2)
+      request_store
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -275,6 +278,8 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.5)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -400,6 +405,7 @@ DEPENDENCIES
   importmap-rails
   kaminari
   laa_multi_step_forms!
+  logstasher (~> 2.1)
   pg (~> 1.5)
   pry
   puma (~> 6.3)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,4 +63,10 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.logstasher.enabled = true
+  config.logstasher.logger_path = 'log/logstasher_development.log'
+  config.logstasher.log_level = Logger::INFO
+  config.logstasher.suppress_app_log = false
+  config.logstasher.source = 'laa-claim-no-standard-magistrates-fee-backed-dev'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,10 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.logstasher.enabled = true
+  config.logstasher.logger_path = 'log/logstasher.log'
+  config.logstasher.log_level = Logger::INFO
+  config.logstasher.suppress_app_log = false
+  config.logstasher.source = "laa-claim-no-standard-magistrates-fee-backed-#{ENV.fetch('ENV', nil)}"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,10 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.logstasher.enabled = true
+  config.logstasher.logger_path = 'log/logstasher_test.log'
+  config.logstasher.log_level = Logger::INFO
+  config.logstasher.suppress_app_log = false
+  config.logstasher.source = 'laa-claim-no-standard-magistrates-fee-backed-test'
 end


### PR DESCRIPTION
## Description of change

- Adds logstasher gem to services
- Adds config to the different environments

## Link to relevant ticket

[CRM457-265](https://dsdmoj.atlassian.net/browse/CRM457-265)

## Notes for reviewer

- Local logs can be found after running the app in `logs/logstasher_development.log`

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature

Service to be deployed and Kibana logs queried
