### PR TITLE
[CRM457-213] Solicitor declaration step

### DIFF
--- a/app/controllers/steps/solicitor_declaration_controller.rb
+++ b/app/controllers/steps/solicitor_declaration_controller.rb
@@ -1,0 +1,20 @@
+module Steps
+  class SolicitorDeclarationController < Steps::BaseStepController
+    def edit
+      @form_object = SolicitorDeclarationForm.build(
+        current_application
+      )
+      Rails.logger.info(current_application[:status].to_json)
+    end
+
+    def update
+      update_and_advance(SolicitorDeclarationForm, as: :solicitor_declaration)
+    end
+
+    private
+
+    def decision_tree_class
+      Decisions::SimpleDecisionTree
+    end
+  end
+end

--- a/app/forms/steps/solicitor_declaration_form.rb
+++ b/app/forms/steps/solicitor_declaration_form.rb
@@ -1,0 +1,15 @@
+require 'steps/base_form_object'
+
+module Steps
+  class SolicitorDeclarationForm < Steps::BaseFormObject
+    attribute :signatory_name, :string
+    validates :signatory_name, presence: true
+
+    private
+
+    def persist!
+      application.status = 'completed'
+      application.update!(attributes)
+    end
+  end
+end

--- a/app/presenters/start_page.rb
+++ b/app/presenters/start_page.rb
@@ -14,10 +14,10 @@ module StartPage
       [:case, [:case_details, :hearing_details, :case_disposal]],
       [:claim,
        [:reason_for_claim, :claim_details, :work_items, :letters_calls, :disbursements, :cost_summary,
-        :additional_info]],
+        :other_info]],
       [:evidence, [:upload_evidence]],
       [:review,
-       [:check_answers, :declaration]],
+       [:check_answers, :solicitor_declaration]],
     ].freeze
   end
 end

--- a/app/presenters/tasks/solicitor_declaration.rb
+++ b/app/presenters/tasks/solicitor_declaration.rb
@@ -1,0 +1,10 @@
+module Tasks
+  class SolicitorDeclaration < Generic
+    PREVIOUS_TASK = OtherInfo
+    FORM = Steps::SolicitorDeclarationForm
+
+    def path
+      edit_steps_solicitor_declaration_path(application)
+    end
+  end
+end

--- a/app/services/decisions/simple_decision_tree.rb
+++ b/app/services/decisions/simple_decision_tree.rb
@@ -10,10 +10,11 @@ module Decisions
       claim_details: :work_item,
       work_item: :work_items,
       disbursement_cost: :disbursements,
+      other_info: :solicitor_declaration,
     }.freeze
 
     SHOW_MAPPING = {
-      other_info: :start_page,
+      solicitor_declaration: :start_page,
     }.freeze
 
     def destination

--- a/app/views/claims/index.html.erb
+++ b/app/views/claims/index.html.erb
@@ -84,7 +84,8 @@
           <tr class="govuk-table__row app-task-list__item">
             <% if claim.status == 'completed' %>
               <td class="govuk-table__cell">
-                <a href="/application_certificate/<%= application.id %>"><%= claim.id %></a>
+                <%# TODO: Keeping it here as we do want to show a different URL for completed claims (TBC) %>
+                <%= link_to claim.short_id, steps_start_page_path(claim.id) %>
               </td>
             <% else %>
               <td class="govuk-table__cell">

--- a/app/views/steps/solicitor_declaration/edit.html.erb
+++ b/app/views/steps/solicitor_declaration/edit.html.erb
@@ -1,0 +1,17 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
+    <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+    <div><%= t '.subheading_html' %></div>
+    <div><%= t '.warning_html' %></div>
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_fieldset legend: { text: t('.legend'), size: 's', class:'govuk-!-margin-bottom-4'} do %>
+        <%= f.govuk_text_field :signatory_name, width: 'two-thirds', autocomplete: 'off'  %>
+      <% end %>
+      <%= f.continue_button(primary: :save_and_submit, secondary: false) %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -249,6 +249,9 @@ en:
           'no': 'No'
         conclusion: Tell us why you did not make this claim within 3 months of the conclusion of the proceedings
 
+      steps_solicitor_declaration_form:
+        signatory_name: Full name
+
     other_disbursement_type:
       accident_reconstruction_report: Accident Reconstruction Report
       accident_emergency_report: Accident & Emergency Report

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -165,6 +165,30 @@ en:
       edit:
         page_title: Other Relevant information
         heading: Other Relevant information
+    solicitor_declaration:
+      edit:
+        page_title: Confirm the following
+        heading: Confirm the following
+        subheading_html: |
+          <p class="govuk-body">You agree that:</p>
+          <ul class="govuk-list govuk-list--bullet">
+              <li> you've provided correct and complete information in this claim </li>
+              <li>the work you are claiming for has not been, and will not be, part of any other claim for remuneration from criminal legal aid</li>
+          </ul>
+        warning_html: |
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-warning-text__assistive">Warning</span>
+              If you provide wrong or incomplete information, or are found to have committed benefit fraud, you may:
+              <ul class="govuk-list govuk-list--bullet govuk-!-font-weight-bold">
+                <li>be prosecuted</li>
+                <li>need to pay a financial penalty</li>
+              </ul>
+            </strong>
+          </div>
+        legend: Legal representative
+
   laa_multi_step_forms:
     task_list:
       show:

--- a/config/locales/en/tasklist.yml
+++ b/config/locales/en/tasklist.yml
@@ -25,10 +25,10 @@ en:
       letters_calls: Letters and phone calls
       disbursements: Disbursements costs
       cost_summary: Review your claim
-      additional_info: Other relevant information
+      other_info: Other relevant information
       upload_evidence: Upload supporting evidence
       check_answers: Check your answers
-      declaration: Confirm declaration and submit claim
+      solicitor_declaration: Confirm declaration and submit claim
   laa_multi_step_forms:
     task_list:
       show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
       edit_step :disbursements
       show_step :cost_summary
       edit_step :other_info
+      edit_step :solicitor_declaration
 
     end
   end

--- a/db/migrate/20230711105344_add_solicitor_declaration_name.rb
+++ b/db/migrate/20230711105344_add_solicitor_declaration_name.rb
@@ -1,0 +1,5 @@
+class AddSolicitorDeclarationName < ActiveRecord::Migration[7.0]
+  def change
+    add_column :claims, :signatory_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_06_142000) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_11_105344) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_06_142000) do
     t.integer "letters_uplift"
     t.date "work_before_date"
     t.date "work_after_date"
+    t.string "signatory_name"
     t.index ["firm_office_id"], name: "index_claims_on_firm_office_id"
     t.index ["solicitor_id"], name: "index_claims_on_solicitor_id"
     t.index ["ufn"], name: "index_claims_on_ufn"

--- a/gems/laa_multi_step_forms/config/locales/en/helpers.yml
+++ b/gems/laa_multi_step_forms/config/locales/en/helpers.yml
@@ -11,7 +11,7 @@ en:
     submit:
       save_and_continue: Save and continue
       save_and_come_back_later: Save and come back later
-      save_and_submit: Save and submit application
+      save_and_submit: Save and submit
       find_address: Find address
       try_again: Try again
       apply_in_eforms: Apply in eForms

--- a/spec/decisions/simple_decision_tree_spec.rb
+++ b/spec/decisions/simple_decision_tree_spec.rb
@@ -127,7 +127,9 @@ RSpec.describe Decisions::SimpleDecisionTree do
                   step_name: :disbursement_delete, controller: :disbursement_type, nested: :disbursement,
                   summary_controller: :disbursements, form_class: Steps::DeleteForm
 
-  it_behaves_like 'a generic decision', :other_info, :start_page, Steps::OtherInfoForm, action_name: :show
+  it_behaves_like 'a generic decision', :other_info, :solicitor_declaration, Steps::OtherInfoForm
+  it_behaves_like 'a generic decision', :solicitor_declaration, :start_page, Steps::SolicitorDeclarationForm,
+                  action_name: :show
 
   context 'when step is unknown' do
     it 'moves to claim index' do

--- a/spec/steps/solicitor_declaration/controller_spec.rb
+++ b/spec/steps/solicitor_declaration/controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Steps::SolicitorDeclarationController, type: :controller do
+  it_behaves_like 'a generic step controller', Steps::SolicitorDeclarationForm, Decisions::SimpleDecisionTree
+  it_behaves_like 'a step that can be drafted', Steps::SolicitorDeclarationForm
+end

--- a/spec/steps/solicitor_declaration/form_spec.rb
+++ b/spec/steps/solicitor_declaration/form_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Steps::SolicitorDeclarationForm do
+  let(:form) { described_class.new(application:, **arguments) }
+
+  let(:arguments) do
+    {
+      application:,
+      signatory_name:,
+    }
+  end
+
+  let(:application) { instance_double(Claim, update!: true, 'status=': true) }
+
+  describe '#save the form' do
+    context 'when all fields are set' do
+      let(:signatory_name) { 'John Doe' }
+
+      it 'is valid' do
+        expect(form.save).to be_truthy
+        expect(application).to have_received(:status=).with('completed')
+        expect(application).to have_received(:update!)
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe 'form is #valid' do
+    context 'when the field is set' do
+      let(:signatory_name) { 'John Doe' }
+
+      it 'is valid' do
+        expect(form).to be_valid
+      end
+    end
+  end
+
+  describe 'form is #invalid' do
+    context 'when the field is empty' do
+      let(:signatory_name) { nil }
+
+      it 'is invalid' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:signatory_name, :blank)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/steps/solicitor_declaration/integration_spec.rb
+++ b/spec/steps/solicitor_declaration/integration_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'User can fill in solicitor declaration', type: :system do
+  let(:claim) { Claim.create(office_code: 'AAAA') }
+
+  before do
+    visit provider_saml_omniauth_callback_path
+  end
+
+  it 'can do green path' do
+    visit edit_steps_solicitor_declaration_path(claim.id)
+
+    fill_in 'Full name',
+            with: 'John Doe'
+    click_on 'Save and submit'
+
+    expect(claim.reload).to have_attributes(
+      signatory_name: 'John Doe',
+      status: 'completed'
+    )
+  end
+end

--- a/spec/steps/solicitor_declaration/presenter_spec.rb
+++ b/spec/steps/solicitor_declaration/presenter_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Tasks::SolicitorDeclaration, type: :system do
+  subject { described_class.new(application:) }
+
+  let(:application) { Claim.create(attributes) }
+  let(:attributes) { { id: id, office_code: 'AAA' } }
+  let(:id) { SecureRandom.uuid }
+
+  describe '#path' do
+    it { expect(subject.path).to eq("/applications/#{id}/steps/solicitor_declaration") }
+  end
+
+  it_behaves_like 'a task with generic complete?', Steps::SolicitorDeclarationForm
+end


### PR DESCRIPTION
## What
This is the page on the form that allows a user to confirm what they have submitted is correct. 

## Link to relevant ticket
[SOLICITOR DECLARATION: Build "Confirm the following" page](https://dsdmoj.atlassian.net/browse/CRM457-213)

## Notes for reviewer
After submission of the claim, status is set to 'completed'. We do need to confirm what to show when user clicks on the 'SUBMITTED' claim in the Main Claim list page. [ref.Screenshot below]. I left a placeholder with a TODO tag for us to change the URL later.
![Screenshot 2023-07-13 at 12 26 38](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/90189839/6e16717c-9379-48e9-9692-a10e4a11e1cd)


## Screenshot
![Screenshot 2023-07-13 at 12 22 45](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/90189839/2226afcc-790e-4a45-91f8-ee2fe243e13e)

