### PR TITLE
Enable duplicate button on work items

### DIFF
--- a/app/controllers/steps/work_item_controller.rb
+++ b/app/controllers/steps/work_item_controller.rb
@@ -20,7 +20,7 @@ module Steps
         new_work_item = work_item.dup
         new_work_item.save!
         redirect_to edit_steps_work_item_path(current_application, work_item_id: new_work_item.id),
-          flash: { success: t('.duplicate') }
+                    flash: { success: t('.duplicate') }
       end
     end
 

--- a/app/controllers/steps/work_item_controller.rb
+++ b/app/controllers/steps/work_item_controller.rb
@@ -13,6 +13,16 @@ module Steps
       update_and_advance(WorkItemForm, as: :work_item, record: work_item)
     end
 
+    def duplicate
+      if work_item.id == StartPage::NEW_RECORD
+        redirect_to edit_steps_work_item_path(current_application, work_item_id: StartPage::NEW_RECORD)
+      else
+        new_work_item = work_item.dup
+        new_work_item.save!
+        redirect_to edit_steps_work_item_path(current_application, work_item_id: new_work_item.id)
+      end
+    end
+
     private
 
     def decision_tree_class

--- a/app/controllers/steps/work_item_controller.rb
+++ b/app/controllers/steps/work_item_controller.rb
@@ -19,7 +19,8 @@ module Steps
       else
         new_work_item = work_item.dup
         new_work_item.save!
-        redirect_to edit_steps_work_item_path(current_application, work_item_id: new_work_item.id)
+        redirect_to edit_steps_work_item_path(current_application, work_item_id: new_work_item.id),
+          flash: { success: t('.duplicate') }
       end
     end
 

--- a/app/views/steps/work_items/edit.html.erb
+++ b/app/views/steps/work_items/edit.html.erb
@@ -25,7 +25,7 @@
               <td class="govuk-table__cell"><%= work_item.fee_earner %></td>
               <td class="govuk-table__cell">
                 <%= link_to t('.change'), edit_steps_work_item_path(@form_object.application, work_item_id: work_item.id) %>
-                <%= link_to t('.duplicate'), edit_steps_work_item_delete_path(@form_object.application, work_item_id: work_item.id) %>
+                <%= link_to t('.duplicate'), duplicate_steps_work_item_path(@form_object.application, work_item_id: work_item.id) %>
                 <%= link_to t('.delete'), edit_steps_work_item_delete_path(@form_object.application, work_item_id: work_item.id) %>
               </td>
             </tr>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -100,6 +100,8 @@ en:
         calculation: Calculation
         before_uplift: Before uplift
         after_uplift: After uplift
+      duplicate:
+        duplicate: Work item successfully duplicated
     work_items:
       edit:
         page_title: Work Items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,27 +1,3 @@
-module RouteHelpers
-  def edit_step(name, opts = {}, &block)
-  resource name,
-           only: opts.fetch(:only, [:edit, :update]),
-           controller: name,
-           path_names: { edit: '' } do; block.call if block_given?; end
-  end
-
-  def crud_step(name, opts = {})
-    edit_step name, only: [] do
-      resources only: [:edit, :update, :destroy],
-                except: opts.fetch(:except, []),
-                controller: name, param: opts.fetch(:param),
-                path_names: { edit: '' } do
-        get :confirm_destroy, on: :member if parent_resource.actions.include?(:destroy)
-      end
-    end
-  end
-
-  def show_step(name)
-    resource name, only: [:show], controller: name
-  end
-end
-
 Rails.application.routes.draw do
   extend RouteHelpers
 
@@ -81,7 +57,11 @@ Rails.application.routes.draw do
       edit_step :reason_for_claim
       edit_step :claim_details
       edit_step :letters_calls
-      crud_step :work_item, param: :work_item_id, except: [:destroy]
+      crud_step :work_item, param: :work_item_id, except: [:destroy] do
+        member do
+          get :duplicate
+        end
+      end
       edit_step :work_items
       crud_step :work_item_delete, param: :work_item_id, except: [:destroy]
       crud_step :disbursement_type, param: :disbursement_id, except: [:destroy]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_091036) do
     t.integer "defence_statement"
     t.integer "number_of_witnesses"
     t.string "supplemental_claim"
+    t.string "preparation_time"
     t.integer "time_spent"
     t.integer "letters"
     t.integer "calls"

--- a/gems/laa_multi_step_forms/.rubocop.yml
+++ b/gems/laa_multi_step_forms/.rubocop.yml
@@ -148,4 +148,4 @@ RSpec/NestedGroups:
 RSpec/ExampleLength:
   Max: 16
   Exclude:
-    - spec/presenters/summary/sections/*
+    - spec/lib/routes_helpers_spec.rb

--- a/gems/laa_multi_step_forms/app/lib/route_helpers.rb
+++ b/gems/laa_multi_step_forms/app/lib/route_helpers.rb
@@ -1,0 +1,26 @@
+module RouteHelpers
+  def edit_step(name, opts = {}, &block)
+    resource name,
+             only: opts.fetch(:only, [:edit, :update]),
+             controller: name,
+             path_names: { edit: '' } do
+      yield if block
+    end
+  end
+
+  def crud_step(name, opts = {}, &block)
+    edit_step name, only: [] do
+      resources only: [:edit, :update, :destroy],
+                except: opts.fetch(:except, []),
+                controller: name, param: opts.fetch(:param),
+                path_names: { edit: '' } do
+        yield if block
+        get :confirm_destroy, on: :member if parent_resource.actions.include?(:destroy)
+      end
+    end
+  end
+
+  def show_step(name)
+    resource name, only: [:show], controller: name
+  end
+end

--- a/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/claim_type_controller.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/claim_type_controller.rb
@@ -1,0 +1,11 @@
+module Steps
+  class ClaimTypeController < Steps::BaseStepController
+    def edit; end
+
+    def update; end
+
+    private
+
+    def decision_tree_class; end
+  end
+end

--- a/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/defendant_controller.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/defendant_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  class DefendantController < Steps::BaseStepController
+    def edit; end
+
+    def update; end
+  end
+end

--- a/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/start_page_controller.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/start_page_controller.rb
@@ -1,0 +1,5 @@
+module Steps
+  class StartPageController < Steps::BaseStepController
+    def show; end
+  end
+end

--- a/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/work_item_controller.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/work_item_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class WorkItemController < Steps::BaseStepController
+    def edit; end
+
+    def update; end
+
+    def duplicate; end
+  end
+end

--- a/gems/laa_multi_step_forms/spec/dummy/config/routes.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  extend RouteHelpers
+
   mount LaaMultiStepForms::Engine => '/laa_multi_step_forms'
 
   put '/dummy_step/:id/after_commit', to: 'home#index', as: :after_commit
@@ -6,4 +8,17 @@ Rails.application.routes.draw do
   put '/dummy_step/:id', to: 'dummy_step#update'
 
   root 'home#index'
+
+  scope 'applications/:id' do
+    namespace :steps do
+      edit_step :claim_type
+      show_step :start_page
+      crud_step :defendant, param: :defendant_id, except: [:destroy]
+      crud_step :work_item, param: :work_item_id do
+        member do
+          get :duplicate
+        end
+      end
+    end
+  end
 end

--- a/gems/laa_multi_step_forms/spec/lib/routes_helpers_spec.rb
+++ b/gems/laa_multi_step_forms/spec/lib/routes_helpers_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe RouteHelpers, type: :routing do
+  let(:id) { SecureRandom.uuid }
+  let(:secondary_id) { SecureRandom.uuid }
+
+  it 'creates show routes' do
+    expect(get("/applications/#{id}/steps/start_page")).to route_to('steps/start_page#show', id:)
+  end
+
+  it 'creates edit routes' do
+    expect(get("/applications/#{id}/steps/claim_type")).to route_to('steps/claim_type#edit', id:)
+    expect(patch("/applications/#{id}/steps/claim_type")).to route_to('steps/claim_type#update', id:)
+    expect(put("/applications/#{id}/steps/claim_type")).to route_to('steps/claim_type#update', id:)
+  end
+
+  it 'creates crud routes - minimal' do
+    expect(get("/applications/#{id}/steps/defendant/#{secondary_id}")).to route_to(
+      'steps/defendant#edit', id: id, defendant_id: secondary_id
+    )
+    expect(patch("/applications/#{id}/steps/defendant/#{secondary_id}")).to route_to(
+      'steps/defendant#update', id: id, defendant_id: secondary_id
+    )
+    expect(put("/applications/#{id}/steps/defendant/#{secondary_id}")).to route_to(
+      'steps/defendant#update', id: id, defendant_id: secondary_id
+    )
+  end
+
+  it 'creates crud routes - with deelete adnd custom' do
+    expect(get("/applications/#{id}/steps/work_item/#{secondary_id}/duplicate")).to route_to(
+      'steps/work_item#duplicate', id: id, work_item_id: secondary_id
+    )
+    expect(get("/applications/#{id}/steps/work_item/#{secondary_id}/confirm_destroy")).to route_to(
+      'steps/work_item#confirm_destroy', id: id, work_item_id: secondary_id
+    )
+    expect(get("/applications/#{id}/steps/work_item/#{secondary_id}")).to route_to(
+      'steps/work_item#edit', id: id, work_item_id: secondary_id
+    )
+    expect(patch("/applications/#{id}/steps/work_item/#{secondary_id}")).to route_to(
+      'steps/work_item#update', id: id, work_item_id: secondary_id
+    )
+    expect(put("/applications/#{id}/steps/work_item/#{secondary_id}")).to route_to(
+      'steps/work_item#update', id: id, work_item_id: secondary_id
+    )
+    expect(delete("/applications/#{id}/steps/work_item/#{secondary_id}")).to route_to(
+      'steps/work_item#destroy', id: id, work_item_id: secondary_id
+    )
+  end
+end

--- a/spec/steps/work_items/integration_spec.rb
+++ b/spec/steps/work_items/integration_spec.rb
@@ -137,4 +137,28 @@ RSpec.describe 'User can manage work items', type: :system do
 
     expect(claim.work_items.count).to eq(0)
   end
+
+  it 'can duplicate a work item' do
+    claim.work_items.create(
+      work_type: 'advocacy',
+      time_spent: 122,
+      completed_on: Date.new(2022, 4, 20),
+      fee_earner: 'BJB',
+      uplift: nil,
+    )
+
+    visit edit_steps_work_items_path(claim.id)
+
+    expect(page).to have_content('Advocacy', count: 1)
+
+    find('.govuk-table__row', text: 'Advocacy').click_on 'Duplicate'
+
+    expect(claim.reload.work_items.count).to eq(2)
+
+    click_on 'Save and continue'
+
+    expect(claim.reload.work_items.count).to eq(2)
+
+    expect(page).to have_content('Advocacy', count: 2)
+  end
 end


### PR DESCRIPTION
## Description of change
Add duplicate functionality for work items

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRM457-207

## Notes for reviewer
This also moves the RouteHelpers module into the gem
