### PR TITLE
[CRM457-214] Claim complete step

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,3 +3,7 @@
 @import "./custom/govuk-summary-list";
 @import "./custom/task_list";
 @import "./custom/accessible-autocomplete";
+
+.govuk-button-group.confirmation-button-group > form {
+    display: inline-flex;
+}

--- a/app/controllers/steps/claim_confirmation_controller.rb
+++ b/app/controllers/steps/claim_confirmation_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  class ClaimConfirmationController < Steps::BaseStepController
+    def show
+      @laa_reference = current_application.laa_reference
+    end
+  end
+end

--- a/app/presenters/tasks/claim_confirmation.rb
+++ b/app/presenters/tasks/claim_confirmation.rb
@@ -1,0 +1,9 @@
+module Tasks
+  class ClaimConfirmation < Generic
+    PREVIOUS_TASK = SolicitorDeclaration
+
+    def path
+      steps_claim_confirmation_path(application)
+    end
+  end
+end

--- a/app/services/decisions/simple_decision_tree.rb
+++ b/app/services/decisions/simple_decision_tree.rb
@@ -14,9 +14,7 @@ module Decisions
     }.freeze
 
     SHOW_MAPPING = {
-      other_info: :start_page,
-      claim_type: :start_page,
-      solicitor_declaration: :start_page,
+      solicitor_declaration: :claim_confirmation,
     }.freeze
 
     def destination

--- a/app/views/steps/claim_confirmation/show.html.erb
+++ b/app/views/steps/claim_confirmation/show.html.erb
@@ -1,0 +1,33 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        <%= t('.panel_heading')%>
+      </h1>
+      <div class="govuk-panel__body">
+        <%= t('.panel_text')%><br><strong><%= @laa_reference%></strong>
+      </div>
+    </div>
+
+    <div class="govuk-!-margin-top-4 govuk-!-margin-bottom-6">
+    <p class="govuk-body"><%= t('.confirmation_email_sent')%></p>
+      <h2 class="govuk-heading-m"><%= t('.next_steps.title')%></h2>
+      <p class="govuk-body"><%= t('.next_steps.process_1')%></p>
+      <p class="govuk-body"><%= t('.next_steps.process_2')%></p>
+      <p class="govuk-body">
+          <a href="#" class="govuk-link"><%= t('.feedback.link_text')%></a>
+          (<%= t('.feedback.description')%>)
+      </p>
+    </div>
+
+    <div class="govuk-button-group confirmation-button-group">
+      <%= link_button t('helpers.view_claims'), applications_path, class: 'govuk-button' %>
+      <%= button_to applications_path, class: "govuk-button govuk-button--secondary" do %>
+        <%= t('helpers.start_new_claim')%>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -12,9 +12,9 @@ en:
         actions: Actions
       status:
         pending: In progress
-        submitted: Submitted
+        completed: Submitted
         accessed: Accessed
       status_colour:
         pending: govuk-tag--grey
-        submitted: govuk-tag--blue
+        completed: govuk-tag--primary
         accessed: govuk-tag--green

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -193,6 +193,19 @@ en:
         warning_list_1: be prosecuted
         warning_list_2: have to pay a penalty
         legend: Legal representative
+    claim_confirmation:
+      show:
+        page_title: Claim complete
+        panel_heading: Claim complete
+        panel_text: Your LAA reference number
+        confirmation_email_sent: "We have sent you a confirmation email."
+        next_steps:
+          title: What happens next
+          process_1: "We'll assess your claim."
+          process_2: "We’ll send you an email to either accept your claim or to ask for more information."
+        feedback:
+          link_text: What did you think of this service?
+          description: takes 30 seconds
 
   laa_multi_step_forms:
     task_list:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ Rails.application.routes.draw do
       edit_step :other_info
       edit_step :equality
       edit_step :solicitor_declaration
+      show_step :claim_confirmation
+
     end
   end
 

--- a/gems/laa_multi_step_forms/config/locales/en/helpers.yml
+++ b/gems/laa_multi_step_forms/config/locales/en/helpers.yml
@@ -8,6 +8,8 @@ en:
   helpers:
     back_link: Back
     start_again: Start again
+    start_new_claim: Start a new claim
+    view_claims: View my claims
     submit:
       save_and_continue: Save and continue
       save_and_come_back_later: Save and come back later

--- a/spec/decisions/simple_decision_tree_spec.rb
+++ b/spec/decisions/simple_decision_tree_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Decisions::SimpleDecisionTree do
     end
   end
 
-  it_behaves_like 'a generic decision', :solicitor_declaration, :start_page, Steps::SolicitorDeclarationForm,
+  it_behaves_like 'a generic decision', :solicitor_declaration, :claim_confirmation, Steps::SolicitorDeclarationForm,
                   action_name: :show
 
   context 'when step is unknown' do

--- a/spec/steps/claim_confirmation/controller_spec.rb
+++ b/spec/steps/claim_confirmation/controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Steps::ClaimConfirmationController, type: :controller do
+  it_behaves_like 'a show step controller'
+
+  describe '#show' do
+    let(:claim) { Claim.create!(office_code: 'AAA') }
+    let(:application) { instance_double(Claim, laa_reference: 'ABC123') }
+
+    it 'assigns the correct application reference' do
+      get :show, params: { id: claim }
+      expect(application.laa_reference).to eq('ABC123')
+    end
+
+    it 'renders the show template' do
+      get :show, params: { id: claim }
+      expect(response).to render_template(:show)
+    end
+  end
+end

--- a/spec/steps/claim_confirmation/integration_spec.rb
+++ b/spec/steps/claim_confirmation/integration_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 
-# it shows LAA reference on the claim confirmation page
-# it can show all claims for a provider
-# it can start a new claim
-
 RSpec.describe 'User can see an application status', type: :system do
   let(:claim) { Claim.create!(office_code: 'AAA', laa_reference: 'ABC123', status: 'completed') }
 
@@ -26,11 +22,11 @@ RSpec.describe 'User can see an application status', type: :system do
   end
 
   it 'can start a new claim when clicking on start a new claim button' do
-    click_on 'Start a new claim'
-    # expect(page).to have_current_path edit_steps_claim_type_path(claim.id)
-    # expect(claim.reload).to have_attributes(
-    #   laa_reference: '',
-    #   status: 'pending',
-    # )
+    expect { click_on 'Start a new claim' }.to change(Claim, :count).by(1)
+    new_claim = Claim.order(:created_at).last
+    expect(page).to have_content('What you are claiming for')
+    expect(new_claim).to have_attributes(
+      status: 'pending',
+    )
   end
 end

--- a/spec/steps/claim_confirmation/integration_spec.rb
+++ b/spec/steps/claim_confirmation/integration_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+# it shows LAA reference on the claim confirmation page
+# it can show all claims for a provider
+# it can start a new claim
+
+RSpec.describe 'User can see an application status', type: :system do
+  let(:claim) { Claim.create!(office_code: 'AAA', laa_reference: 'ABC123', status: 'completed') }
+
+  before do
+    visit provider_saml_omniauth_callback_path
+    visit steps_claim_confirmation_path(claim.id)
+  end
+
+  it 'shows LAA reference on the claim confirmation page' do
+    expect(page).to have_css('div.govuk-panel__body', text: claim.laa_reference)
+  end
+
+  it 'can show all claims for a provider when clicking on view my claims button' do
+    click_on 'View my claims'
+    expect(page).to have_current_path(applications_path)
+    expect(claim.reload).to have_attributes(
+      laa_reference: 'ABC123',
+      status: 'completed',
+    )
+  end
+
+  it 'can start a new claim when clicking on start a new claim button' do
+    click_on 'Start a new claim'
+    # expect(page).to have_current_path edit_steps_claim_type_path(claim.id)
+    # expect(claim.reload).to have_attributes(
+    #   laa_reference: '',
+    #   status: 'pending',
+    # )
+  end
+end

--- a/spec/steps/claim_confirmation/presenter_spec.rb
+++ b/spec/steps/claim_confirmation/presenter_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Tasks::ClaimConfirmation, type: :system do
+  subject { described_class.new(application:) }
+
+  let(:application) { Claim.new(attributes) }
+  let(:attributes) do
+    {
+      id: id,
+      office_code: 'AAA',
+      navigation_stack: navigation_stack
+    }
+  end
+  let(:id) { SecureRandom.uuid }
+  let(:navigation_stack) { [] }
+
+  describe '#path' do
+    it { expect(subject.path).to eq("/applications/#{id}/steps/claim_confirmation") }
+  end
+end


### PR DESCRIPTION
## What
This is the page on the form that allows a user to be assured that they have submitted their claim.
## Ticket
[CLAIM COMPLETE: Build page](https://dsdmoj.atlassian.net/browse/CRM457-214) 

## Screenshot
![Screenshot 2023-07-14 at 15 14 59](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/90189839/80592df0-9b7b-4b0b-9aa3-11a00af35d4a)

## ToDo
- [x] Integration test for 'Start a new claim'
- [x] Integration test for 'View my claims'
- [x] Test for controller
- [x] Test for presenter
- [x] Fix Tag styling for 'Submitted'