### PR TITLE
Up all envs to 500MB memory limit

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -57,10 +57,10 @@ ingress:
 resources:
   limits:
     cpu: 500m
-    memory: 125Mi
+    memory: 500Mi
   requests:
     cpu: 10m
-    memory: 125Mi
+    memory: 500Mi
 
 autoscaling:
   enabled: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -57,10 +57,10 @@ ingress:
 resources:
   limits:
     cpu: 500m
-    memory: 125Mi
+    memory: 500Mi
   requests:
     cpu: 10m
-    memory: 125Mi
+    memory: 500Mi
 
 autoscaling:
   enabled: false

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -57,10 +57,10 @@ ingress:
 resources:
   limits:
     cpu: 500m
-    memory: 250Mi
+    memory: 500Mi
   requests:
     cpu: 10m
-    memory: 250Mi
+    memory: 500Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Description of change
Up all envs to 500MB memory limit in helm chart

## Link to relevant ticket
[Intermittent Gateway Issues
](https://dsdmoj.atlassian.net/browse/CRM457-238)


