### PR TITLE
Build form in the same way as the .build method

### DIFF
--- a/app/forms/steps/letters_calls_form.rb
+++ b/app/forms/steps/letters_calls_form.rb
@@ -112,11 +112,11 @@ module Steps
     end
 
     def letters_before_uplift
-      letters.to_f * pricing.letters if letters
+      letters.to_f * pricing.letters if letters && !letters.zero?
     end
 
     def calls_before_uplift
-      calls.to_f * pricing.letters if calls
+      calls.to_f * pricing.letters if calls && !calls.zero?
     end
   end
 end

--- a/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
+++ b/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
@@ -27,7 +27,7 @@ module Steps
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def update_and_advance(form_class, opts = {})
       hash = permitted_params(form_class).to_h
-      record = opts[:record]
+      record = opts.fetch(:record, current_application)
 
       @form_object = form_class.new(
         hash.merge(application: current_application, record: record)

--- a/gems/laa_multi_step_forms/spec/controllers/steps/base_step_controller_spec.rb
+++ b/gems/laa_multi_step_forms/spec/controllers/steps/base_step_controller_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe DummyStepController, type: :controller do
       it 'sets the paramters on the form' do
         expect(form_class).to receive(:new).with({
                                                    'application' => application,
-          'record' => nil,
+          'record' => application,
           'first' => '1',
           'second' => '2',
                                                  })
@@ -182,7 +182,7 @@ RSpec.describe DummyStepController, type: :controller do
         it 'ignore additional and skips missing params' do
           expect(form_class).to receive(:new).with({
                                                      'application' => application,
-            'record' => nil,
+            'record' => application,
             'first' => '1',
                                                    })
 
@@ -211,7 +211,7 @@ RSpec.describe DummyStepController, type: :controller do
       it 'sets the paramters on the form' do
         expect(form_class).to receive(:new).with({
                                                    'application' => application,
-          'record' => nil,
+          'record' => application,
           'first' => '1',
           'second' => '2',
                                                  })
@@ -225,7 +225,7 @@ RSpec.describe DummyStepController, type: :controller do
         it 'ignore additional and skips missing params' do
           expect(form_class).to receive(:new).with({
                                                      'application' => application,
-            'record' => nil,
+            'record' => application,
             'first' => '1',
                                                    })
 
@@ -262,7 +262,7 @@ RSpec.describe DummyStepController, type: :controller do
       it 'sets the paramters on the form' do
         expect(form_class).to receive(:new).with({
                                                    'application' => application,
-          'record' => nil,
+          'record' => application,
           'first' => '1',
           'second' => '2',
                                                  })

--- a/spec/steps/letters_calls/integration_spec.rb
+++ b/spec/steps/letters_calls/integration_spec.rb
@@ -34,4 +34,24 @@ RSpec.describe 'User can fill in claim type details', type: :system do
       calls_uplift: 20,
     )
   end
+
+  it 'can do the calculation' do
+    visit edit_steps_letters_calls_path(claim.id)
+
+    fill_in 'Number of letters', with: 1
+    fill_in 'Number of phone calls', with: 2
+
+    click_on 'Update the calculation'
+
+    expect(claim.reload).to have_attributes(
+      letters: 1,
+      calls: 2,
+      letters_uplift: nil,
+      calls_uplift: nil,
+    )
+
+    within '.govuk-table__body' do
+      expect(page.text).to eq('Letters£4.09£4.09Phone calls£8.18£8.18')
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
So we have two ways to build the form object, either directly from the `new` method or using the `build` method.. when using the build method the record is set to the application if it is not passed in. This change replicates that when building the form in the update path of the controller

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRM457-272
