### PR TITLE
[CRM457-274] Fix font size on the Claim details step

### DIFF
--- a/app/views/steps/claim_details/edit.html.erb
+++ b/app/views/steps/claim_details/edit.html.erb
@@ -6,16 +6,16 @@
     <%= govuk_error_summary(@form_object) %>
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_number_field :prosecution_evidence, min: 1, step: 1, width: 3 %>
-      <%= f.govuk_number_field :defence_statement, min: 1, step: 1, width: 3 %>
-      <%= f.govuk_number_field :number_of_witnesses, min: 1, step: 1, width: 3 %>
+      <%= f.govuk_number_field :prosecution_evidence,label:{ size: 's'}, min: 1, step: 1, width: 3 %>
+      <%= f.govuk_number_field :defence_statement,label:{ size: 's'}, min: 1, step: 1, width: 3 %>
+      <%= f.govuk_number_field :number_of_witnesses,label:{ size: 's'}, min: 1, step: 1, width: 3 %>
       <% @form_object.boolean_fields.each do |field| %>
-        <%= f.govuk_radio_buttons_fieldset field, legend: { size: 'm' } do %>
+        <%= f.govuk_radio_buttons_fieldset field, legend: { size: 's' } do %>
           <%= f.govuk_radio_button field, YesNoAnswer::YES.to_s do%>
             <% if field == :preparation_time %>
-              <%= f.govuk_period_field :time_spent, width: 'one-third' %>
+              <%= f.govuk_period_field :time_spent,legend: { size: 's', class: 'govuk-!-font-weight-regular' }, width: 'one-third' %>
             <% elsif %i[work_before work_after].include?(field) %>
-              <%= f.govuk_date_field "#{field}_date", width: 'one-third' %>
+              <%= f.govuk_date_field "#{field}_date",legend: { size: 's', class: 'govuk-!-font-weight-regular' }, width: 'one-third' %>
             <% end %>
           <% end %>
           <%= f.govuk_radio_button field, YesNoAnswer::NO.to_s %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -36,13 +36,13 @@ en:
       steps_claim_details_form:
         claim_details: Claim Details
         number_of_witnesses: Number of Defence witnesses
-        supplemental_claim: Does this bill represent supplemental claim?
+        supplemental_claim: Does this bill represent a supplemental claim?
         preparation_time: Did you spend time watching or listening to recorded evidence?
         time_spent: Running time of the recording
         work_before_date: Date you started this work
         work_after_date: Date of last court hearing
         work_before: Did you do any work before the representation order date?
-        work_after: Did you do any further work after the last court hearing date?
+        work_after: Did you do any further work after the last court hearing?
       steps_other_info_form:
         concluded: Did the proceedings conclude over 3 months ago?
       steps_work_item_form:

--- a/spec/steps/claim_details/integration_spec.rb
+++ b/spec/steps/claim_details/integration_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'User can fill in claim details', type: :system do
     fill_in 'Number of pages of defence statements', with: '2'
     fill_in 'Number of witnesses', with: '3'
 
-    find('.govuk-form-group', text: 'Does this bill represent supplemental claim?').choose 'Yes'
+    find('.govuk-form-group', text: 'Does this bill represent a supplemental claim?').choose 'Yes'
     find('.govuk-form-group',
          text: 'Did you spend time watching or listening to recorded evidence?').choose 'Yes'
     fill_in 'Hours', with: 10
@@ -25,7 +25,7 @@ RSpec.describe 'User can fill in claim details', type: :system do
       fill_in 'Month', with: '3'
       fill_in 'Year', with: '2023'
     end
-    find('.govuk-form-group', text: 'Did you do any further work after the last court hearing date?').choose 'No'
+    find('.govuk-form-group', text: 'Did you do any further work after the last court hearing?').choose 'No'
 
     click_on 'Save and continue'
     expect(claim.reload).to have_attributes(


### PR DESCRIPTION
## What

This fixes the styling issues in Claim details step based on Figma file.


## Ticket
[Fix font size on the Claim details step](https://dsdmoj.atlassian.net/browse/CRM457-274)

## Screenshot
**Before**
![screencapture-crm7dev-apps-live-cloud-platform-service-justice-gov-uk-applications-bd7845eb-44dd-4ef2-b5bf-bc207705e741-steps-claim-details-2023-07-19-14_00_27](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/90189839/d4bfb007-667a-4ebb-b529-7e883ece4ad9)
**Now**
![screencapture-localhost-3000-applications-91ae9ec1-6164-406f-b341-b4441a3bb2a2-steps-claim-details-2023-07-20-09_13_54](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/90189839/8b5a47cd-f0bb-4357-8973-dedb2230d1aa)
