### PR TITLE
Ensure cost summary renders when nil total cost

### DIFF
--- a/app/presenters/cost_summary/report.rb
+++ b/app/presenters/cost_summary/report.rb
@@ -27,7 +27,7 @@ module CostSummary
     end
 
     def total_cost
-      NumberTo.pounds(items.values.sum(&:total_cost))
+      NumberTo.pounds(items.values.map(&:total_cost).compact.sum)
     end
 
     private

--- a/spec/presenters/cost_summary/report_spec.rb
+++ b/spec/presenters/cost_summary/report_spec.rb
@@ -111,5 +111,14 @@ RSpec.describe CostSummary::Report do
     it 'sums the cost values' do
       expect(subject.total_cost).to eq('£230.00')
     end
+
+    context 'when a section has a nil total cost' do
+      let(:l_total_cost) { nil }
+
+      it 'does not raise an error' do
+        expect { subject.total_cost }.not_to raise_error
+        expect(subject.total_cost).to eq('£130.00')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Fix bug introduces by return nil as total cost from LettersCallsForm when value is 0

## Link to relevant ticket
N/A
