### PR TITLE
Make letters and calls optional

### DIFF
--- a/app/forms/steps/letters_calls_form.rb
+++ b/app/forms/steps/letters_calls_form.rb
@@ -9,8 +9,8 @@ module Steps
     attribute :letters_uplift, :integer
     attribute :calls_uplift, :integer
 
-    validates :letters, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-    validates :calls, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+    validates :letters, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
+    validates :calls, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
     validates :letters_uplift, presence: true,
       numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
       if: :apply_letters_uplift

--- a/app/lib/pricing.rb
+++ b/app/lib/pricing.rb
@@ -14,6 +14,8 @@ class Pricing
   end
 
   FIELDS = %w[
+    name
+
     preparation
     advocacy
     attendance_with_counsel
@@ -37,6 +39,7 @@ class Pricing
     FIELDS.each do |field|
       instance_variable_set("@#{field}", data.fetch(field, nil)&.to_f)
     end
+    @name = data.fetch('name', nil)
   end
 
   def [](key)

--- a/app/presenters/cost_summary/letters_calls.rb
+++ b/app/presenters/cost_summary/letters_calls.rb
@@ -10,19 +10,21 @@ module CostSummary
       [
         {
           key: { text: translate('letters'), classes: 'govuk-summary-list__value-width-50' },
-          value: { text: NumberTo.pounds(letters_calls_form.letters_after_uplift) },
+          value: { text: NumberTo.pounds(letters_calls_form.letters_after_uplift || 0) },
         },
         {
           key: { text: translate('calls'), classes: 'govuk-summary-list__value-width-50' },
-          value: { text: NumberTo.pounds(letters_calls_form.calls_after_uplift) },
+          value: { text: NumberTo.pounds(letters_calls_form.calls_after_uplift || 0) },
         }
       ]
     end
 
-    delegate :total_cost, to: :letters_calls_form
+    def total_cost
+      letters_calls_form.total_cost || 0
+    end
 
     def title
-      translate('letters_calls', total: NumberTo.pounds(total_cost))
+      translate('letters_calls', total: NumberTo.pounds(total_cost || 0))
     end
   end
 end

--- a/app/presenters/cost_summary/work_items.rb
+++ b/app/presenters/cost_summary/work_items.rb
@@ -16,7 +16,7 @@ module CostSummary
         total_cost = forms[work_type]&.sum(&:total_cost)
         {
           key: { text: translate(work_type.to_s), classes: 'govuk-summary-list__value-width-50' },
-          value: { text: NumberTo.pounds(total_cost) },
+          value: { text: NumberTo.pounds(total_cost || 0) },
         }
       end
     end

--- a/app/views/steps/letters_calls/edit.html.erb
+++ b/app/views/steps/letters_calls/edit.html.erb
@@ -4,11 +4,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
-    <h2 class="govuk-heading-s govuk-!-margin-bottom-6"><%= t '.subheading_html' %></h2>
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_number_field :letters, min: 1, step: 1, width: 3, data:{rate_letters: @form_object.pricing.letters} %>
+      <%= f.govuk_number_field :letters, min: 1, step: 1, width: 3, label: { size: 's' }, hint: { value: @form_object.pricing.name }, data: { rate_letters: @form_object.pricing.letters } %>
       <% if @form_object.allow_uplift? %>
         <%= f.govuk_check_boxes_fieldset :apply_letters_uplift, multiple: false, legend: nil, data: { cy: 'apply-letters-uplift' } do %>
           <%= f.govuk_check_box :apply_letters_uplift, 'true', 'false', multiple: false do %>
@@ -16,10 +15,10 @@
           <% end %>
         <% end %>
       <% end %>
-      <%= f.govuk_number_field :calls, min: 1, step: 1, width: 3, data:{rate_phone_calls: @form_object.pricing.calls} %>
+      <%= f.govuk_number_field :calls, min: 1, step: 1, width: 3, label: { size: 's' }, hint: { value: @form_object.pricing.name }, data: { rate_phone_calls: @form_object.pricing.calls } %>
       <% if @form_object.allow_uplift? %>
         <%= f.govuk_check_boxes_fieldset :apply_calls_uplift, multiple: false, legend: nil, data: { cy: 'apply-calls-uplift' } do %>
-          <%= f.govuk_check_box :apply_calls_uplift, 'true', 'false', multiple: false do %>
+          <%= f.govuk_check_box :apply_calls_uplift, 'true', 'false', multiple: false  do %>
             <%= f.govuk_number_field :calls_uplift, min: 1, step: 1, max: 100, width: 3, suffix_text: '%' %>
           <% end %>
         <% end %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -101,6 +101,13 @@ en:
         completed_on: For example, 27 3 2007
         fee_earner: For example, JMD
         period: For example, 1 hour and 30 minutes
+      steps_letters_calls_form:
+        letters_options:
+          from_start: You will get £3.56 for each letter
+          from_20220930: You will get £4.09 for each letter
+        calls_options:
+          from_start: You will get £3.56 for each call
+          from_20220930: You will get £4.09 for each call
       steps_disbursement_type_form:
         disbursement_date: For example, 27 3 2007
         disbursement_type_options:
@@ -224,8 +231,8 @@ en:
           'true': Apply an uplift to this work
         uplift: For example, from any percentage from 1 to 100
       steps_letters_calls_form:
-        letters: Number of letters
-        calls: Number of phone calls
+        letters: Number of letters (optional)
+        calls: Number of phone calls (optional)
         apply_letters_uplift_options:
           'true': Apply an uplift to this work
         apply_calls_uplift_options:

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -75,12 +75,6 @@ en:
       edit:
         page_title: Letters and phone calls
         heading: Letters and phone calls
-        subheading_html: |
-          <p class="govuk-body">For each letter or telephone call you will get:</p>
-          <ul class="govuk-list govuk-list--bullet">
-              <li>£3.56 for representation orders before 30 September 2022</li>
-              <li>£4.09 for representation orders on or after 30 September 2022</li>
-          </ul>
         total_cost: Total cost
         summary: View by letters and phone calls
         items: Items

--- a/config/pricing.yml
+++ b/config/pricing.yml
@@ -1,4 +1,5 @@
 from_start:
+  name: from_start
   # working types
   preparation: 45.35
   advocacy: 56.89
@@ -16,6 +17,7 @@ from_start:
   # disbursement cost
   vat: 0.2
 from_20220930:
+  name: from_20220930
   # working types
   preparation: 52.15
   advocacy: 65.42

--- a/spec/lib/pricing_spec.rb
+++ b/spec/lib/pricing_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Pricing do
       it 'returns the current (post CLAIR) pricing' do
         expect(described_class).to receive(:new).with(
           {
+            'name' => 'from_20220930',
             'preparation' => 52.15,
             'advocacy' => 65.42,
             'attendance_with_counsel' => 35.68,
@@ -36,6 +37,7 @@ RSpec.describe Pricing do
       it 'returns the current (post CLAIR) pricing' do
         expect(described_class).to receive(:new).with(
           {
+            'name' => 'from_20220930',
             'preparation' => 52.15,
             'advocacy' => 65.42,
             'attendance_with_counsel' => 35.68,
@@ -60,6 +62,7 @@ RSpec.describe Pricing do
       it 'returns the old (pre CLAIR) pricing' do
         expect(described_class).to receive(:new).with(
           {
+            'name' => 'from_start',
             'preparation' => 45.35,
             'advocacy' => 56.89,
             'attendance_with_counsel' => 31.03,
@@ -89,7 +92,7 @@ RSpec.describe Pricing do
   end
 
   describe 'accessing field' do
-    Pricing::FIELDS.each do |field|
+    (Pricing::FIELDS - ['name']).each do |field|
       context "when #{field}" do
         it 'can be access via method call' do
           expect(subject.public_send(field).to_f).not_to eq(0.0)
@@ -102,6 +105,16 @@ RSpec.describe Pricing do
         it 'returns the same value regardless of access method' do
           expect(subject.public_send(field).to_f).to eq(subject[field].to_f)
         end
+      end
+    end
+
+    context 'when name' do
+      it 'can be access via method call' do
+        expect(subject.name).to eq('from_20220930')
+      end
+
+      it 'can be access via [] syntax' do
+        expect(subject[:name]).to eq('from_20220930')
       end
     end
   end

--- a/spec/presenters/cost_summary/work_items_spec.rb
+++ b/spec/presenters/cost_summary/work_items_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CostSummary::WorkItems do
         [
           {
             key: { classes: 'govuk-summary-list__value-width-50', text: 'Attendance without counsel' },
-            value: { text: '£' }
+            value: { text: '£0.00' }
           },
           {
             key: { classes: 'govuk-summary-list__value-width-50', text: 'Preparation' },

--- a/spec/steps/cost_summary/integration_spec.rb
+++ b/spec/steps/cost_summary/integration_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'User can see cost breakdowns', type: :system do
         'Work items total £260.68',
         'Items', 'Total per item',
         'Attendance without counsel', '£53.52', # 35.68 * 90 / 60
-        'Preparation', '£',
+        'Preparation', '£0.00',
         'Advocacy', '£207.16', # 65.42 * (104 + 86) / 60
         'Total', '£260.68',
 

--- a/spec/steps/letters_calls/form_spec.rb
+++ b/spec/steps/letters_calls/form_spec.rb
@@ -40,8 +40,7 @@ RSpec.describe Steps::LettersCallsForm do
         let(:letters) { '' }
 
         it 'have an error' do
-          expect(subject).not_to be_valid
-          expect(subject.errors.of_kind?(:letters, :blank)).to be(true)
+          expect(subject).to be_valid
         end
       end
 
@@ -72,8 +71,7 @@ RSpec.describe Steps::LettersCallsForm do
         let(:calls) { '' }
 
         it 'have an error' do
-          expect(subject).not_to be_valid
-          expect(subject.errors.of_kind?(:calls, :blank)).to be(true)
+          expect(subject).to be_valid
         end
       end
 


### PR DESCRIPTION
## Description of change
Make letters and calls options
Small UI fixes 
* align letters and calls page with design
* use `£0.00` instead of `£` in cost summary

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRM457-268

## Screenshots of changes (if applicable)
<img width="479" alt="Screenshot 2023-07-25 at 14 49 18" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/63736/b29dba70-9c18-4173-a340-4f5a7b5b59ed">

