### PR TITLE
Check Answers: Default letters/calls to 0 if not input

### DIFF
--- a/app/presenters/check_answers/letters_calls_card.rb
+++ b/app/presenters/check_answers/letters_calls_card.rb
@@ -19,7 +19,7 @@ module CheckAnswers
         },
         {
           head_key: 'letters',
-          text: letters_calls_form.letters
+          text: letters
         },
         {
           head_key: 'letters_uplift',
@@ -31,7 +31,7 @@ module CheckAnswers
         },
         {
           head_key: 'calls',
-          text: letters_calls_form.calls
+          text: calls
         },
         {
           head_key: 'calls_uplift',
@@ -64,6 +64,14 @@ module CheckAnswers
     def total_cost
       text = "<strong>#{currency_value(letters_calls_form.total_cost)}</strong>"
       ApplicationController.helpers.sanitize(text, tags: %w[strong])
+    end
+
+    def letters
+      letters_calls_form.letters || 0
+    end
+
+    def calls
+      letters_calls_form.calls || 0
     end
   end
 end

--- a/spec/presenters/check_answers/letters_calls_card_spec.rb
+++ b/spec/presenters/check_answers/letters_calls_card_spec.rb
@@ -125,6 +125,56 @@ calls_after_uplift:, total_cost:)
         )
       end
     end
+
+    context 'no letters or calls requested' do
+      let(:letters_uplift) { nil }
+      let(:calls_uplift) { nil }
+      let(:letters_after_uplift) { nil }
+      let(:calls_after_uplift) { nil }
+      let(:total_cost) { 0 }
+      let(:letters) { nil }
+      let(:calls) { nil }
+
+      it 'generates letters and calls rows' do
+        expect(subject.row_data).to eq(
+          [
+            {
+              head_key: 'items',
+              text: '<strong>Total per item</strong>'
+            },
+            {
+              head_key: 'letters',
+              text: 0
+            },
+            {
+              head_key: 'letters_uplift',
+              text: '0%'
+            },
+            {
+              head_key: 'letters_payment',
+              text: '£0.00'
+            },
+            {
+              head_key: 'calls',
+              text: 0
+            },
+            {
+              head_key: 'calls_uplift',
+              text: '0%'
+            },
+            {
+              head_key: 'calls_payment',
+              text: '£0.00'
+            },
+            {
+              head_key: 'total',
+              text: '<strong>£0.00</strong>',
+              footer: true
+            }
+          ]
+        )
+      end
+    end
   end
   # rubocop:enable RSpec/ExampleLength
 end


### PR DESCRIPTION
## Description of change
Have default on Letters/Calls section of Check Answers page of 0 for letters/calls


## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/26544538/e3f68343-09e4-4fba-a28f-66d18a32b030)

### After changes:
![image](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/26544538/12fd4417-8d70-4c99-83cb-5e16c4d80f23)

