### PR TITLE
Align all lines to the left in "start a new claim" page

### DIFF
--- a/app/assets/stylesheets/custom/task_list.scss
+++ b/app/assets/stylesheets/custom/task_list.scss
@@ -24,6 +24,11 @@
   @include govuk-responsive-margin(5, "left", $adjustment: 0);
   @include govuk-responsive-padding(5, "top", $adjustment: 0);
 }
+
 .moj-task-list__item:first-child {
   border-top: none;
+}
+
+.moj-task-list__items {
+  padding-left: 0;
 }


### PR DESCRIPTION
## Description of change
Add custom css to set padding-left to 0 for task-list__items

## Link to relevant ticket
Align all lines to the left in "start a new claim" page

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/26544538/87f7fed7-cc97-4e7c-a534-5acba3292a8b)

### After changes:


