### PR TITLE
CRM457-437 - Add details card

### DIFF
--- a/app/presenters/check_answers/claim_type_card.rb
+++ b/app/presenters/check_answers/claim_type_card.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module CheckAnswers
+  class ClaimTypeCard < Base
+    attr_reader :claim
+
+    def initialize(claim)
+      @group = 'claim_type'
+      @section = 'claim_type'
+      @claim = claim
+    end
+
+    def row_data
+      claim_rows = is_magistrates_claim ? magistrates_claim : breach_claim
+
+      base_rows + claim_rows
+    end
+
+    def base_rows
+      [
+        {
+          head_key: 'file_ufn',
+          text: claim.ufn
+        },
+        {
+          head_key: 'type_of_claim',
+          text: translate_table_key(section, claim.claim_type)
+        }
+      ]
+    end
+
+    def magistrates_claim
+      [
+        {
+          head_key: 'rep_order_date',
+          text: claim.rep_order_date&.strftime('%d %B %Y')
+        }
+      ]
+    end
+
+    def breach_claim
+      [
+        {
+          head_key: 'cntp_number',
+          text: claim.cntp_order
+        },
+        {
+          head_key: 'cntp_rep_order',
+          text: claim.cntp_date&.strftime('%d %B %Y')
+        }
+      ]
+    end
+
+    def is_magistrates_claim
+      claim.claim_type == ClaimType::NON_STANDARD_MAGISTRATE.to_s
+    end
+  end
+end
+

--- a/app/presenters/check_answers/claim_type_card.rb
+++ b/app/presenters/check_answers/claim_type_card.rb
@@ -11,7 +11,7 @@ module CheckAnswers
     end
 
     def row_data
-      claim_rows = is_magistrates_claim ? magistrates_claim : breach_claim
+      claim_rows = magistrates_claim? ? magistrates_rows : breach_rows
 
       base_rows + claim_rows
     end
@@ -29,16 +29,16 @@ module CheckAnswers
       ]
     end
 
-    def magistrates_claim
+    def magistrates_rows
       [
         {
           head_key: 'rep_order_date',
-          text: claim.rep_order_date&.strftime('%d %B %Y')
+          text: claim.rep_order_date.try(:strftime, '%d %B %Y')
         }
       ]
     end
 
-    def breach_claim
+    def breach_rows
       [
         {
           head_key: 'cntp_number',
@@ -46,14 +46,13 @@ module CheckAnswers
         },
         {
           head_key: 'cntp_rep_order',
-          text: claim.cntp_date&.strftime('%d %B %Y')
+          text: claim.cntp_date.try(:strftime, '%d %B %Y')
         }
       ]
     end
 
-    def is_magistrates_claim
+    def magistrates_claim?
       claim.claim_type == ClaimType::NON_STANDARD_MAGISTRATE.to_s
     end
   end
 end
-

--- a/app/presenters/check_answers/report.rb
+++ b/app/presenters/check_answers/report.rb
@@ -3,6 +3,7 @@ module CheckAnswers
     include GovukLinkHelper
     include ActionView::Helpers::UrlHelper
     GROUPS = %w[
+      claim_type
       about_you
       about_defendant
       about_case
@@ -39,6 +40,10 @@ module CheckAnswers
           rows: data.rows
         }
       end
+    end
+
+    def claim_type_section
+      [ClaimTypeCard.new(claim)]
     end
 
     def about_you_section

--- a/config/locales/en/check_answers.yml
+++ b/config/locales/en/check_answers.yml
@@ -6,6 +6,14 @@ en:
         page_title: Check your answers
         heading: Check your answers
         sections:
+          claim_type:
+            file_ufn: Unique file number
+            type_of_claim: Type of claim
+            rep_order_date: Representation order date
+            cntp_number: Client's CNTP number
+            cntp_rep_order: Date CNTP representation order was issued
+            non_standard_magistrate: Non-standard magistrates' court payment
+            breach_of_injunction: Breach of injunction
           firm_details:
             firm_name: Firm name
             firm_account_number: Firm account number
@@ -90,6 +98,10 @@ en:
             send_by_post: Sending supporting evidence by post
             supporting_evidence: Evidence %{count}
       groups:
+        claim_type:
+          heading: What you are claiming for
+          claim_type:
+            title: What you are claiming for
         about_you:
           heading: About you
           firm_details:

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -16,6 +16,19 @@ FactoryBot.define do
       one_disbursement
     end
 
+    trait :case_type_magistrates do
+      ufn { '123456/001' }
+      claim_type { 'non_standard_magistrate' }
+      rep_order_date { '2023-01-01' }
+    end
+
+    trait :case_type_breach do
+      ufn { '123456/002' }
+      claim_type { 'breach_of_injunction' }
+      cntp_order { 'CNTP12345' }
+      cntp_date { '2023-02-01' }
+    end
+
     trait :firm_details do
       firm_office factory: %i[firm_office valid]
       solicitor factory: %i[solicitor valid]

--- a/spec/presenters/check_answers/claim_type_card_spec.rb
+++ b/spec/presenters/check_answers/claim_type_card_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CheckAnswers::ClaimTypeCard do
+  subject { described_class.new(claim) }
+
+  describe '#title' do
+    let(:claim) { build(:claim) }
+
+    it 'shows correct title' do
+      expect(subject.title).to eq('What you are claiming for')
+    end
+  end
+
+  describe '#row_data' do
+    context 'non standard magistrates claim' do
+      let(:claim) { build(:claim, :case_type_magistrates) }
+
+      it 'generates magistrates rows' do
+        expect(subject.row_data).to eq(
+          [
+            {
+              head_key: 'file_ufn',
+              text: '123456/001'
+            },
+            {
+              head_key: 'type_of_claim',
+              text: "Non-standard magistrates' court payment"
+            },
+            {
+              head_key: 'rep_order_date',
+              text: '01 January 2023'
+            }
+          ]
+        )
+      end
+    end
+
+    context 'breach of injunction claim' do
+      let(:claim) { build(:claim, :case_type_breach) }
+
+      it 'generates magistrates rows' do
+        expect(subject.row_data).to eq(
+          [
+            {
+              head_key: 'file_ufn',
+              text: '123456/002'
+            },
+            {
+              head_key: 'type_of_claim',
+
+              text: 'Breach of injunction'
+            },
+            {
+              head_key: 'cntp_number',
+              text: 'CNTP12345'
+            },
+            {
+              head_key: 'cntp_rep_order',
+              text: '01 February 2023'
+            }
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Adds the high level details card for a claim

## Link to relevant ticket

[CRM457-437](https://dsdmoj.atlassian.net/browse/CRM457-437)

## Notes for reviewer

## Screenshots of changes (if applicable)

<img width="1065" alt="Screenshot 2023-09-13 at 22 13 44" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/95fb12e7-509d-4751-a727-58859975e818">
<img width="1026" alt="Screenshot 2023-09-13 at 22 17 00" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/5db35d1b-8735-49aa-bcc6-6f2b1a7dffe5">

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-437]: https://dsdmoj.atlassian.net/browse/CRM457-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ