### PR TITLE
CRM457-403 Add answer_equality to DB

### DIFF
--- a/app/forms/steps/answer_equality_form.rb
+++ b/app/forms/steps/answer_equality_form.rb
@@ -4,13 +4,9 @@ require 'steps/base_form_object'
 # or skip them, as such it does not persist anything to DB
 module Steps
   class AnswerEqualityForm < Steps::BaseFormObject
-    attr_reader :answer_equality
+    attribute :answer_equality, :value_object, source: YesNoAnswer
 
     validates :answer_equality, presence: true, inclusion: { in: YesNoAnswer.values }
-
-    def answer_equality=(value)
-      @answer_equality = value.present? ? YesNoAnswer.new(value) : nil
-    end
 
     def choices
       YesNoAnswer.values
@@ -19,7 +15,7 @@ module Steps
     private
 
     def persist!
-      true
+      application.update!(attributes)
     end
   end
 end

--- a/db/migrate/20230920054312_add_equality_answer.rb
+++ b/db/migrate/20230920054312_add_equality_answer.rb
@@ -1,0 +1,5 @@
+class AddEqualityAnswer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :claims, :answer_equality, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_24_105533) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_20_054312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -101,6 +101,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_105533) do
     t.string "has_disbursements"
     t.uuid "submitter_id"
     t.string "is_other_info"
+    t.string "answer_equality"
     t.index ["firm_office_id"], name: "index_claims_on_firm_office_id"
     t.index ["solicitor_id"], name: "index_claims_on_solicitor_id"
     t.index ["ufn"], name: "index_claims_on_ufn"

--- a/spec/services/notify_app_store/message_builder_spec.rb
+++ b/spec/services/notify_app_store/message_builder_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe NotifyAppStore::MessageBuilder do
       expect(tester).to have_received(:process).with(
         application: {
           'agent_instructed' => 'no',
+          'answer_equality' => nil,
           'arrest_warrant_date' => nil,
           'assigned_counsel' => 'no',
           'claim_type' => nil,

--- a/spec/steps/equality/form_spec.rb
+++ b/spec/steps/equality/form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Steps::AnswerEqualityForm do
     }
   end
 
-  let(:application) { double(:application) }
+  let(:application) { instance_double(Claim, update!: true) }
   let(:answer_equality) { nil }
 
   describe '#choices' do
@@ -43,8 +43,12 @@ RSpec.describe Steps::AnswerEqualityForm do
   describe '#save' do
     let(:answer_equality) { 'yes' }
 
-    it 'does not persist anything' do
-      expect(subject.save).to be_truthy
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+
+    it 'saves the form' do
+      expect(form.save).to be_truthy
     end
   end
 end


### PR DESCRIPTION
## Description of change

- Adds the answer_equality field to the database

## Link to relevant ticket

[CRM457-403](https://dsdmoj.atlassian.net/browse/CRM457-403)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-403]: https://dsdmoj.atlassian.net/browse/CRM457-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ