### PR TITLE
CRM457-531 - Adds readonly view for submitted claims

### DIFF
--- a/app/controllers/steps/start_page_controller.rb
+++ b/app/controllers/steps/start_page_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   class StartPageController < Steps::BaseStepController
     def show
+      return redirect_to steps_view_claim_path(current_application.id) if current_application.status == 'completed'
+
       @pre_tasklist = StartPage::PreTaskList.new(
         view_context, application: current_application, show_index: false
       )

--- a/app/controllers/steps/view_claim_controller.rb
+++ b/app/controllers/steps/view_claim_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Steps
+  class ViewClaimController < Steps::BaseStepController
+    def show
+      @report = CheckAnswers::Report.new(current_application, read_only: true)
+    end
+  end
+end

--- a/app/presenters/check_answers/report.rb
+++ b/app/presenters/check_answers/report.rb
@@ -13,8 +13,9 @@ module CheckAnswers
 
     attr_reader :claim
 
-    def initialize(claim)
+    def initialize(claim, read_only: false)
       @claim = claim
+      @readonly = read_only
     end
 
     def section_groups
@@ -82,6 +83,8 @@ module CheckAnswers
     private
 
     def actions(key)
+      return [] if @readonly
+
       helper = Rails.application.routes.url_helpers
       [
         govuk_link_to(

--- a/app/views/claims/index.html.erb
+++ b/app/views/claims/index.html.erb
@@ -79,15 +79,8 @@
         <% @claims.each do |claim| %>
           <tr class="govuk-table__row app-task-list__item">
             <td class="govuk-table__cell">
-              <% if claim.status == 'completed' %>
-                <%# TODO: Keeping it here as we do want to show a different URL for completed claims (TBC) %>
-                <%= link_to steps_start_page_path(claim.id) do %>
-                  <%= claim.ufn %>
-                <% end %>
-              <% else %>
-                <%= link_to steps_start_page_path(claim.id) do %>
-                  <%= claim.ufn %>
-                <% end %>
+              <%= link_to steps_start_page_path(claim.id) do %>
+                <%= claim.ufn %>
               <% end %>
             </td>
             <td class="govuk-table__cell"><%= check_missing(claim.main_defendant&.full_name) %></td>

--- a/app/views/steps/view_claim/show.html.erb
+++ b/app/views/steps/view_claim/show.html.erb
@@ -1,0 +1,14 @@
+<% title t('.page_title') %>
+<% decision_step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+    <% @report.section_groups.each do |section_group| %>
+      <h2 class="govuk-heading-l"><%= section_group[:heading] %></h2>
+      <% section_group[:sections].each do |section| %>
+        <%= govuk_summary_list(**section) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -258,6 +258,10 @@ en:
         feedback:
           link_text: What did you think of this service?
           description: takes 30 seconds
+    view_claim:
+      show:
+        page_title: View your claim
+        heading: View your claim
   laa_multi_step_forms:
     task_list:
       show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,7 @@ Rails.application.routes.draw do
       edit_step :solicitor_declaration
       show_step :claim_confirmation
       show_step :check_answers
-
+      show_step :view_claim
     end
   end
 

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -149,5 +149,9 @@ FactoryBot.define do
     trait :high_cost_disbursement do
       disbursements { [build(:disbursement, :valid_high_cost)] }
     end
+
+    trait :completed_status do
+      status { 'complete' }
+    end
   end
 end

--- a/spec/presenters/check_answers/report_spec.rb
+++ b/spec/presenters/check_answers/report_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CheckAnswers::Report do
+  describe '#section_groups' do
+    context 'not in a complete state' do
+      subject { described_class.new(claim) }
+
+      let(:claim) { build(:claim, :complete) }
+
+      context 'section groups' do
+        it 'returns multiple groups' do
+          expect(subject.section_groups).to be_an_instance_of Array
+          expect(subject.section_groups.count).to eq 6
+        end
+      end
+
+      context 'section group' do
+        let(:section_group) { subject.section_group('claim_type', subject.claim_type_section) }
+
+        it 'returns a section object' do
+          expect(section_group[:heading]).to eq 'What you are claiming for'
+          expect(section_group[:sections].count).to eq 1
+        end
+      end
+
+      context 'sections' do
+        let(:section) { subject.sections(subject.claim_type_section) }
+
+        it 'returns group of cards' do
+          expect(section.count).to eq 1
+        end
+
+        it 'has option to change' do
+          expect(section[0][:card][:actions]).to include(
+            "<a class=\"govuk-link\" href=\"/applications/#{claim.id}/steps/claim_type\">Change</a>"
+          )
+        end
+      end
+
+      context 'claim type section' do
+        it 'returns multiple elements' do
+          expect(subject.claim_type_section.count).to eq 1
+        end
+      end
+
+      context 'about you section' do
+        it 'returns multiple elements' do
+          expect(subject.about_you_section.count).to eq 1
+        end
+      end
+
+      context 'about defendants section' do
+        it 'returns multiple elements' do
+          expect(subject.about_defendant_section.count).to eq 1
+        end
+      end
+
+      context 'about case section' do
+        it 'returns multiple elements' do
+          expect(subject.about_case_section.count).to eq 3
+        end
+      end
+
+      context 'about claim section' do
+        it 'returns multiple elements' do
+          expect(subject.about_claim_section.count).to eq 6
+        end
+      end
+
+      context 'supporting evidence section' do
+        it 'returns a single element' do
+          expect(subject.supporting_evidence_section.count).to eq 1
+        end
+      end
+    end
+
+    context 'in a complete state' do
+      subject { described_class.new(claim, read_only: true) }
+
+      let(:claim) { build(:claim, :complete, :completed_status) }
+
+      context 'section groups' do
+        it 'returns multiple groups' do
+          expect(subject.section_groups).to be_an_instance_of Array
+          expect(subject.section_groups.count).to eq 6
+        end
+      end
+
+      context 'section group' do
+        let(:section_group) { subject.section_group('claim_type', subject.claim_type_section) }
+
+        it 'returns a section object' do
+          expect(section_group[:heading]).to eq 'What you are claiming for'
+          expect(section_group[:sections].count).to eq 1
+        end
+      end
+
+      context 'sections' do
+        let(:section) { subject.sections(subject.claim_type_section) }
+
+        it 'returns group of cards' do
+          expect(section.count).to eq 1
+        end
+
+        it 'has option to change' do
+          expect(section[0][:card][:actions]).to eq []
+        end
+      end
+
+      context 'claim type section' do
+        it 'returns multiple elements' do
+          expect(subject.claim_type_section.count).to eq 1
+        end
+      end
+
+      context 'about you section' do
+        it 'returns multiple elements' do
+          expect(subject.about_you_section.count).to eq 1
+        end
+      end
+
+      context 'about defendants section' do
+        it 'returns multiple elements' do
+          expect(subject.about_defendant_section.count).to eq 1
+        end
+      end
+
+      context 'about case section' do
+        it 'returns multiple elements' do
+          expect(subject.about_case_section.count).to eq 3
+        end
+      end
+
+      context 'about claim section' do
+        it 'returns multiple elements' do
+          expect(subject.about_claim_section.count).to eq 6
+        end
+      end
+
+      context 'supporting evidence section' do
+        it 'returns a single element' do
+          expect(subject.supporting_evidence_section.count).to eq 1
+        end
+      end
+    end
+  end
+end

--- a/spec/steps/start_page/controller_spec.rb
+++ b/spec/steps/start_page/controller_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe Steps::StartPageController, type: :controller do
   describe '#show' do
     let(:claim) { create(:claim) }
 
-    before { claim.update(navigation_stack:) }
+    before { claim.update(navigation_stack:, status:) }
 
     context 'when page is already in navigation stack' do
       let(:navigation_stack) { ["/applications/#{claim.id}/steps/start_page", '/foo'] }
+      let(:status) { 'draft' }
 
       it 'does not change the navigation stack' do
         get :show, params: { id: claim }
@@ -21,12 +22,24 @@ RSpec.describe Steps::StartPageController, type: :controller do
 
     context 'when page is not in the navigation stack' do
       let(:navigation_stack) { ['/foo'] }
+      let(:status) { 'draft' }
 
       it 'adds the page to the navigation stack' do
         get :show, params: { id: claim }
         expect(claim.reload).to have_attributes(
           navigation_stack: ['/foo', "/applications/#{claim.id}/steps/start_page"]
         )
+      end
+    end
+
+    context 'when claim is in a completed state' do
+      let(:navigation_stack) { ['/foo'] }
+      let(:status) { 'completed' }
+
+      it 'redirects to the read only view' do
+        get :show, params: { id: claim }
+
+        expect(response).should redirect_to("/applications/#{claim.id}/steps/view_claim")
       end
     end
   end

--- a/spec/steps/view_claim/controller_spec.rb
+++ b/spec/steps/view_claim/controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Steps::ViewClaimController, type: :controller do
+  it_behaves_like 'a show step controller'
+
+  describe '#show' do
+    let(:claim) { create(:claim, :complete, :completed_status) }
+
+    before { claim.update(navigation_stack:) }
+
+    context 'when page is already in navigation stack and at the end' do
+      let(:navigation_stack) { ['/foo', "/applications/#{claim.id}/steps/view_claim"] }
+
+      it 'does not change the navigation stack' do
+        get :show, params: { id: claim }
+        expect(claim.reload).to have_attributes(
+          navigation_stack:
+        )
+      end
+    end
+
+    context 'when page is already in navigation stack but not at the end' do
+      let(:navigation_stack) { ["/applications/#{claim.id}/steps/view_claim"] }
+
+      it 'removes entries after the page' do
+        get :show, params: { id: claim }
+        expect(claim.reload).to have_attributes(
+          navigation_stack: ["/applications/#{claim.id}/steps/view_claim"]
+        )
+      end
+    end
+
+    context 'when page is not in the navigation stack' do
+      let(:navigation_stack) { ['/foo'] }
+
+      it 'adds the page to the navigation stack' do
+        get :show, params: { id: claim }
+        expect(claim.reload).to have_attributes(
+          navigation_stack: ['/foo', "/applications/#{claim.id}/steps/view_claim"]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

- Add readonly view logic into start page controller
- Adds readonly view step
- Utilise and update tests on existing report functions
- Remove ability to change the items

## Link to relevant ticket

[CRM457-531](https://dsdmoj.atlassian.net/browse/CRM457-531)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-531]: https://dsdmoj.atlassian.net/browse/CRM457-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ