### PR TITLE
CRM457-644 - Risk out to be string

### DIFF
--- a/app/services/risk_assessment/risk_assessment_scorer.rb
+++ b/app/services/risk_assessment/risk_assessment_scorer.rb
@@ -3,9 +3,9 @@
 module RiskAssessment
   class RiskAssessmentScorer
     RISK_LEVELS = {
-      high: { id: 1, level: 'high' },
-      medium: { id: 2, level: 'medium' },
-      low: { id: 3, level: 'low' }
+      high: 'high',
+      medium: 'medium',
+      low: 'low'
     }.freeze
     def self.calculate(claim)
       return RISK_LEVELS[:high] if high_risk? claim

--- a/spec/services/risk_assessment/risk_assessment_scorer_spec.rb
+++ b/spec/services/risk_assessment/risk_assessment_scorer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RiskAssessment::RiskAssessmentScorer do
       let(:claim) { build(:claim, :with_assigned_council) }
 
       it do
-        expect(described_class.calculate(claim)).to eq({ id: 1, level: 'high' })
+        expect(described_class.calculate(claim)).to eq('high')
       end
     end
 
@@ -16,7 +16,7 @@ RSpec.describe RiskAssessment::RiskAssessmentScorer do
       let(:claim) { build(:claim, :medium_risk_work_item) }
 
       it do
-        expect(described_class.calculate(claim)).to eq({ id: 2, level: 'medium' })
+        expect(described_class.calculate(claim)).to eq('medium')
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe RiskAssessment::RiskAssessmentScorer do
       let(:claim) { build(:claim) }
 
       it do
-        expect(described_class.calculate(claim)).to eq({ id: 3, level: 'low' })
+        expect(described_class.calculate(claim)).to eq('low')
       end
     end
   end


### PR DESCRIPTION
## Description of change

- Change risk levels to be string instead of dict
- Update tests

## Link to relevant ticket

[CRM457-644](https://dsdmoj.atlassian.net/browse/CRM457-644)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-644]: https://dsdmoj.atlassian.net/browse/CRM457-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ