### PR TITLE
CRM457-645 - Add supporting evidence to outputted message

### DIFF
--- a/app/services/notify_app_store/message_builder.rb
+++ b/app/services/notify_app_store/message_builder.rb
@@ -32,7 +32,8 @@ class NotifyAppStore
         'defendants' => defendant_data,
         'firm_office' => claim.firm_office.attributes.slice!('id', *DEFAULT_IGNORE),
         'solicitor' => claim.solicitor.attributes.slice!('id', *DEFAULT_IGNORE),
-        'submiter' => claim.submitter.attributes.slice('email', 'description'),
+        'submitter' => claim.submitter.attributes.slice('email', 'description'),
+        'supporting_evidences' => supporting_evidence
       )
     end
     # rubocop:enable Metrics/AbcSize
@@ -64,6 +65,12 @@ class NotifyAppStore
 
     def pricing
       @pricing ||= Pricing.for(claim)
+    end
+
+    def supporting_evidence
+      claim.supporting_evidence.map do |evidence|
+        evidence.as_json.slice!('claim_id')
+      end
     end
   end
 end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
       letters_calls
       one_work_item
       one_disbursement
+      with_evidence
     end
 
     trait :case_type_magistrates do
@@ -152,6 +153,10 @@ FactoryBot.define do
 
     trait :completed_status do
       status { 'complete' }
+    end
+
+    trait :with_evidence do
+      supporting_evidence { [build(:supporting_evidence)] }
     end
   end
 end

--- a/spec/factories/supporting_evidence.rb
+++ b/spec/factories/supporting_evidence.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :supporting_evidence do
+    id { '9abe1541-00d7-43d1-ad10-4d3ee5a012bb' }
+    claim_id { SecureRandom.uuid }
+    file_name { 'test.png' }
+    file_type { 'image/png' }
+    file_size { '1234' }
+    created_at { Date.new(2023, 3, 1) }
+    updated_at { Date.new(2023, 3, 1) }
+    file_path { 'test_path' }
+  end
+end

--- a/spec/services/notify_app_store/message_builder_spec.rb
+++ b/spec/services/notify_app_store/message_builder_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe NotifyAppStore::MessageBuilder do
             'reference_number' => '111222'
           },
           'status' => 'draft',
-          'submiter' => { 'description' => nil, 'email' => 'provider@example.com' },
+          'submitter' => { 'description' => nil, 'email' => 'provider@example.com' },
           'supplemental_claim' => nil,
           'time_spent' => nil,
           'ufn' => '20150612/001',
@@ -121,7 +121,17 @@ RSpec.describe NotifyAppStore::MessageBuilder do
             'uplift' => nil,
             'work_type' => { en: an_instance_of(String), value: work_item.work_type },
           }],
-          'youth_count' => 'no'
+          'youth_count' => 'no',
+          'supporting_evidences' =>
+            [{
+              'created_at' => '2023-03-01T00:00:00.000Z',
+               'file_name' => 'test.png',
+               'file_path' => 'test_path',
+               'file_size' => 1234,
+               'file_type' => 'image/png',
+               'id' => '9abe1541-00d7-43d1-ad10-4d3ee5a012bb',
+               'updated_at' => '2023-03-01T00:00:00.000Z'
+            }]
         },
         application_id: claim.id,
         application_state: 'submitted',


### PR DESCRIPTION
## Description of change

- Adds supporting evidence to the outputted message
- Updates the tests

## Link to relevant ticket

[CRM457-645](https://dsdmoj.atlassian.net/browse/CRM457-645)

## Notes for reviewer

Test should show output, otherwise JSON can be intercepted or viewed by sending to appstore locally

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-645]: https://dsdmoj.atlassian.net/browse/CRM457-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ