### PR TITLE
CRM457-645 - Add Cookie Banner

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -186,3 +186,7 @@ Rails/RedundantActiveRecordAllMethod:
   Exclude:
     - 'spec/steps/**/*'
     - 'app/presenters/**/*'
+
+# Causing false positives when implemented in methods
+Rails/ActionControllerFlashBeforeRender:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'sentry-ruby'
 gem 'sidekiq', '~> 7.1'
 gem 'sidekiq_alive', '~> 2.3'
 gem 'sprockets-rails'
+gem 'turbo-rails', '~> 1.4.0'
 gem 'tzinfo-data'
 
 # required as can't specify github in gemspe for laa_multi_step_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.23.3)
+    google-protobuf (3.23.3-x86_64-linux)
     govuk-components (4.1.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
@@ -262,6 +263,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
@@ -408,6 +411,8 @@ GEM
     sass-embedded (1.63.5)
       google-protobuf (~> 3.23)
       rake (>= 13.0.0)
+    sass-embedded (1.63.5-x86_64-linux-gnu)
+      google-protobuf (~> 3.23)
     sentry-rails (5.12.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.12.0)
@@ -445,6 +450,10 @@ GEM
       patience_diff
     thor (1.2.2)
     timeout (0.4.0)
+    turbo-rails (1.4.0)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2023.3)
@@ -467,6 +476,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1.136)
@@ -506,6 +516,7 @@ DEPENDENCIES
   simplecov-rcov
   sprockets-rails
   super_diff
+  turbo-rails (~> 1.4.0)
   tzinfo-data
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,6 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.23.3)
-    google-protobuf (3.23.3-x86_64-linux)
     govuk-components (4.1.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (~> 6.0)
@@ -263,8 +262,6 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
@@ -411,8 +408,6 @@ GEM
     sass-embedded (1.63.5)
       google-protobuf (~> 3.23)
       rake (>= 13.0.0)
-    sass-embedded (1.63.5-x86_64-linux-gnu)
-      google-protobuf (~> 3.23)
     sentry-rails (5.12.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.12.0)
@@ -476,7 +471,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1.136)

--- a/app/controllers/about/cookies_controller.rb
+++ b/app/controllers/about/cookies_controller.rb
@@ -10,8 +10,35 @@ module About
       store_previous_page_url
     end
 
+    def create
+      @cookie = Cookie.new(cookie_params[:cookie])
+      if @cookie.valid?
+        set_cookies
+        set_flash_notification
+        redirect_to about_cookies_path
+      else
+        render :index
+      end
+    end
+
+    private
+
+    def set_cookies
+      set_cookie(:analytics_cookies_set, value: @cookie.analytics)
+      set_cookie(:cookies_preferences_set, value: true)
+    end
+
+    def set_flash_notification
+      previous_page_path = session.delete(:return_to)
+      flash.now[:success] = t('cookie_settings.notification_banner.preferences_set_html', href: previous_page_path)
+    end
+
     def store_previous_page_url
       session[:return_to] = request.referer
+    end
+
+    def cookie_params
+      params.permit(cookie: :analytics)
     end
   end
 end

--- a/app/controllers/about/cookies_controller.rb
+++ b/app/controllers/about/cookies_controller.rb
@@ -30,7 +30,7 @@ module About
 
     def set_flash_notification
       previous_page_path = session.delete(:return_to)
-      flash.now[:success] = t('cookie_settings.notification_banner.preferences_set_html', href: previous_page_path)
+      flash[:success] = t('cookie_settings.notification_banner.preferences_set_html', href: previous_page_path)
     end
 
     def store_previous_page_url

--- a/app/controllers/about/cookies_controller.rb
+++ b/app/controllers/about/cookies_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module About
+  class CookiesController < ApplicationController
+    skip_before_action :authenticate_provider!
+
+    def index
+      usage_cookie = cookies[:analytics_cookies_set]
+      @cookie = Cookie.new(analytics: usage_cookie)
+      store_previous_page_url
+    end
+
+    def store_previous_page_url
+      session[:return_to] = request.referer
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
 class ApplicationController < LaaMultiStepForms::ApplicationController
   include ApplicationHelper
+  include CookieConcern
+
+  before_action :set_default_cookies
 end

--- a/app/controllers/concerns/cookie_concern.rb
+++ b/app/controllers/concerns/cookie_concern.rb
@@ -18,7 +18,7 @@ module CookieConcern
     return set_default_analytics_cookies unless cookies[:cookies_preferences_set]
 
     @analytics_cookies_accepted = ActiveModel::Type::Boolean.new.cast(cookies[:analytics_cookies_set])
-    show_hide_cookie_banners
+    @cookie_preferences_set = show_hide_cookie_banners
   end
 
   private
@@ -31,6 +31,7 @@ module CookieConcern
     else
       set_cookie(:analytics_cookies_set, value: false)
       remove_analytics_cookies
+      @analytics_cookies_accepted = false
     end
 
     set_cookie(:cookies_preferences_set, value: true)
@@ -55,6 +56,6 @@ module CookieConcern
   end
 
   def show_hide_cookie_banners
-    @cookie_preferences_set = cookies[:cookies_preferences_set]
+    cookies[:cookies_preferences_set]
   end
 end

--- a/app/controllers/concerns/cookie_concern.rb
+++ b/app/controllers/concerns/cookie_concern.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module CookieConcern
+  extend ActiveSupport::Concern
+
+  def update_cookies
+    cookie_params = params.permit(:cookies_preference, :hide_banner)
+
+    render(partial: 'layouts/cookie_banner/hide') && return if params['hide_banner'] == 'true'
+
+    update_analytics_cookies(cookie_params[:cookies_preference])
+
+    render(partial: 'layouts/cookie_banner/success',
+           locals: { analytics_cookies_accepted: cookies[:analytics_cookies_set] })
+  end
+
+  def set_default_cookies
+    return set_default_analytics_cookies unless cookies[:cookies_preferences_set]
+
+    @analytics_cookies_accepted = ActiveModel::Type::Boolean.new.cast(cookies[:analytics_cookies_set])
+    show_hide_cookie_banners
+  end
+
+  private
+
+  def update_analytics_cookies(preference)
+    case preference
+    when 'true'
+      set_cookie(:analytics_cookies_set, value: true)
+      @analytics_cookies_accepted = true
+    else
+      set_cookie(:analytics_cookies_set, value: false)
+      remove_analytics_cookies
+    end
+
+    set_cookie(:cookies_preferences_set, value: true)
+  end
+
+  def set_cookie(type, value: false)
+    cookies[type] = {
+      value: value,
+      domain: request.host,
+      expires: 1.year.from_now,
+      secure: !Rails.env.test?
+    }
+  end
+
+  def set_default_analytics_cookies
+    set_cookie(:analytics_cookies_set)
+  end
+
+  def remove_analytics_cookies
+    cookies.delete :_ga, domain: '.justice.gov.uk'
+    cookies.delete :_gid, domain: '.justice.gov.uk'
+  end
+
+  def show_hide_cookie_banners
+    @cookie_preferences_set = cookies[:cookies_preferences_set]
+  end
+end

--- a/app/controllers/concerns/cookie_concern.rb
+++ b/app/controllers/concerns/cookie_concern.rb
@@ -8,7 +8,7 @@ module CookieConcern
 
     render(partial: 'layouts/cookie_banner/hide') && return if params['hide_banner'] == 'true'
 
-    update_analytics_cookies(cookie_params[:cookies_preference])
+    update_analytics_cookies(ActiveModel::Type::Boolean.new.cast(cookie_params[:cookies_preference]))
 
     render(partial: 'layouts/cookie_banner/success',
            locals: { analytics_cookies_accepted: cookies[:analytics_cookies_set] })
@@ -24,15 +24,10 @@ module CookieConcern
   private
 
   def update_analytics_cookies(preference)
-    case preference
-    when 'true'
-      set_cookie(:analytics_cookies_set, value: true)
-      @analytics_cookies_accepted = true
-    else
-      set_cookie(:analytics_cookies_set, value: false)
-      remove_analytics_cookies
-      @analytics_cookies_accepted = false
-    end
+    set_cookie(:analytics_cookies_set, value: preference)
+    @analytics_cookies_accepted = preference
+
+    remove_analytics_cookies unless preference
 
     set_cookie(:cookies_preferences_set, value: true)
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,7 +3,11 @@
 // https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
 import { initAll } from 'govuk-frontend'
 import accessibleAutocomplete from 'accessible-autocomplete'
+import '@hotwired/turbo-rails'
+
 initAll()
+
+Turbo.setFormMode('optin')
 
 const $inputs = document.querySelectorAll('[data-module="govuk-input"]')
 if ($inputs) {
@@ -32,4 +36,4 @@ if ($acElements) {
 const $headerNavigation = document.querySelector('ul.app-header-menu-hidden-on-load')
 if ($headerNavigation) {
   $headerNavigation.classList.remove("app-header-menu-hidden-on-load")
-}import "@hotwired/turbo-rails"
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -32,4 +32,4 @@ if ($acElements) {
 const $headerNavigation = document.querySelector('ul.app-header-menu-hidden-on-load')
 if ($headerNavigation) {
   $headerNavigation.classList.remove("app-header-menu-hidden-on-load")
-}
+}import "@hotwired/turbo-rails"

--- a/app/models/cookie.rb
+++ b/app/models/cookie.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Cookie
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Attributes
+
+  attribute :analytics
+
+  validates :analytics, presence: true
+  validates :analytics, inclusion: { in: %w[true false] }
+end

--- a/app/views/about/cookies/index.html.erb
+++ b/app/views/about/cookies/index.html.erb
@@ -24,9 +24,9 @@
     <table class="govuk-table">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header"><%= t('cookie_settings.essential_cookies.table.name')%></th>
-        <th class="govuk-table__header"><%= t('cookie_settings.essential_cookies.table.purpose')%></th>
-        <th class="govuk-table__header"><%= t('cookie_settings.essential_cookies.table.expires')%></th>
+        <th class="govuk-table__header" scope="col"><%= t('cookie_settings.essential_cookies.table.name')%></th>
+        <th class="govuk-table__header" scope="col"><%= t('cookie_settings.essential_cookies.table.purpose')%></th>
+        <th class="govuk-table__header" scope="col"><%= t('cookie_settings.essential_cookies.table.expires')%></th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">

--- a/app/views/about/cookies/index.html.erb
+++ b/app/views/about/cookies/index.html.erb
@@ -98,7 +98,7 @@
       Change your cookie settings
     </h3>
 
-    <%= form_with model: @cookie, url: about_cookies_path, method: :put do |f| %>
+    <%= form_with model: @cookie, url: about_cookies_path, method: :post do |f| %>
       <%= f.govuk_collection_radio_buttons :analytics,
                                            [['true', t('cookie_settings.form.cookies_on')],
                                             ['false', t('cookie_settings.form.cookies_off')]], :first,

--- a/app/views/about/cookies/index.html.erb
+++ b/app/views/about/cookies/index.html.erb
@@ -31,7 +31,7 @@
       </thead>
       <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header">
+        <th class="govuk-table__header" scope="col">
           <%= t('cookie_settings.essential_cookies.table.row.name_1')%>
         </th>
         <td class="govuk-table__cell">
@@ -42,7 +42,7 @@
         </td>
       </tr>
       <tr class="govuk-table__row">
-        <th class="govuk-table__header">
+        <th class="govuk-table__header" scope="col">
           <%= Rails.configuration.x.analytics.cookies_consent_name %>
         </th>
         <td class="govuk-table__cell">
@@ -53,7 +53,7 @@
         </td>
       </tr>
       <tr class="govuk-table__row">
-        <th class="govuk-table__header">
+        <th class="govuk-table__header" scope="col">
           <%= Rails.configuration.x.analytics.analytics_consent_name %>
         </th>
         <td class="govuk-table__cell">

--- a/app/views/about/cookies/index.html.erb
+++ b/app/views/about/cookies/index.html.erb
@@ -1,4 +1,4 @@
-<% title 'Cookies' %>
+<% title t('cookie_settings.title') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
@@ -7,42 +7,38 @@
                  flash: { success: t(".settings_updated.#{flash['cookies_consent_updated']}") }
                } if flash['cookies_consent_updated'] %>
 
-    <h1 class="govuk-heading-xl">Cookies</h1>
+    <h1 class="govuk-heading-xl"><%= t('cookie_settings.heading') %></h1>
 
-    <p class="govuk-body">The ‘<%= service_name %>’ service puts small files (known as ‘cookies’) onto your device to collect
-      information about how you use the service.</p>
+    <p class="govuk-body"><%= t('cookie_settings.paragraph_1', service: service_name) %></p>
 
-    <p class="govuk-body">You’ll normally see a message on the site before we set a cookie on your device.</p>
+    <p class="govuk-body"><%= t('cookie_settings.paragraph_2') %></p>
 
-    <p class="govuk-body">Cookies are not used to identify you personally.</p>
+    <p class="govuk-body"><%= t('cookie_settings.paragraph_3') %></p>
 
-    <p class="govuk-body">Find out
-      <a class="govuk-link" rel="external" target="_blank" href="https://ico.org.uk/for-the-public/online/cookies">how
-        to manage cookies</a> from the Information Commissioner’s Office.</p>
+    <p class="govuk-body"><%= t('cookie_settings.paragraph_4').html_safe %></p>
 
-    <h2 class="govuk-heading-l">Essential cookies (strictly necessary)</h2>
+    <h2 class="govuk-heading-l"><%= t('cookie_settings.essential_cookies.heading')%></h2>
 
-    <p class="govuk-body">We use these cookies to remember your progress on this device and your cookie consent
-      settings.</p>
+    <p class="govuk-body"><%= t('cookie_settings.essential_cookies.info')%></p>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th class="govuk-table__header">Name</th>
-        <th class="govuk-table__header">Purpose</th>
-        <th class="govuk-table__header">Expires</th>
+        <th class="govuk-table__header"><%= t('cookie_settings.essential_cookies.table.name')%></th>
+        <th class="govuk-table__header"><%= t('cookie_settings.essential_cookies.table.purpose')%></th>
+        <th class="govuk-table__header"><%= t('cookie_settings.essential_cookies.table.expires')%></th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">
-          _crm7restbackend_session
+          <%= t('cookie_settings.essential_cookies.table.row.name_1')%>
         </th>
         <td class="govuk-table__cell">
-          Saves your current progress on this device and tracks inactivity periods
+          <%= t('cookie_settings.essential_cookies.table.row.purpose_1')%>
         </td>
         <td class="govuk-table__cell">
-          When you close your browser
+          <%= t('cookie_settings.essential_cookies.table.row.expires_1')%>
         </td>
       </tr>
       <tr class="govuk-table__row">
@@ -50,7 +46,7 @@
           <%= Rails.configuration.x.analytics.cookies_consent_name %>
         </th>
         <td class="govuk-table__cell">
-          Saves your cookie consent settings
+          <%= t('cookie_settings.essential_cookies.table.row.purpose_2')%>
         </td>
         <td class="govuk-table__cell">
           After <%= Rails.configuration.x.analytics.cookies_consent_expiration.inspect %>
@@ -61,7 +57,7 @@
           <%= Rails.configuration.x.analytics.analytics_consent_name %>
         </th>
         <td class="govuk-table__cell">
-          Saves your analytics consent settings
+          <%= t('cookie_settings.essential_cookies.table.row.purpose_3')%>
         </td>
         <td class="govuk-table__cell">
           After <%= Rails.configuration.x.analytics.analytics_consent_expiration.inspect %>
@@ -70,32 +66,28 @@
       </tbody>
     </table>
 
-    <h2 class="govuk-heading-l">Analytics cookies (optional)</h2>
-    <p class="govuk-body">
-      We use Google Analytics software to collect information about how you use this service. We do this to help make sure
-      this service is meeting the needs of its users and to help us make improvements. Google Analytics stores information
-      about:
-    </p>
+    <h2 class="govuk-heading-l"><%= t('cookie_settings.analytics_cookies.heading') %></h2>
+    <p class="govuk-body"><%= t('cookie_settings.analytics_cookies.info') %></p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>the pages you visit</li>
-      <li>how long you spend on each page</li>
-      <li>the device and browser you use</li>
-      <li>what you click on while you’re visiting the site</li>
+      <li><%= t('cookie_settings.analytics_cookies.list_1.item_1') %></li>
+      <li><%= t('cookie_settings.analytics_cookies.list_1.item_2') %></li>
+      <li><%= t('cookie_settings.analytics_cookies.list_1.item_3') %></li>
+      <li><%= t('cookie_settings.analytics_cookies.list_1.item_4') %></li>
     </ul>
 
-    <p class="govuk-body">We do not allow Google to use or share our analytics data.</p>
+    <p class="govuk-body"><%= t('cookie_settings.analytics_cookies.paragraph_1') %></p>
 
-    <p class="govuk-body">We only set analytics cookies when:</p>
+    <p class="govuk-body"><%= t('cookie_settings.analytics_cookies.paragraph_2') %></p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>you’ve accepted them</li>
-      <li>JavaScript is running in your browser</li>
+      <li><%= t('cookie_settings.analytics_cookies.list_2.item_1') %></li>
+      <li><%= t('cookie_settings.analytics_cookies.list_2.item_2') %></li>
     </ul>
 
-    <p class="govuk-body"> If you choose not to run JavaScript we will only set essential cookies.</p>
+    <p class="govuk-body"><%= t('cookie_settings.analytics_cookies.paragraph_3') %></p>
 
     <h3 class="govuk-heading-m govuk-!-margin-top-8">
-      Change your cookie settings
+      <%= t('cookie_settings.analytics_cookies.change_settings_heading') %>
     </h3>
 
     <%= form_with model: @cookie, url: about_cookies_path, method: :post do |f| %>

--- a/app/views/about/cookies/index.html.erb
+++ b/app/views/about/cookies/index.html.erb
@@ -22,6 +22,9 @@
     <p class="govuk-body"><%= t('cookie_settings.essential_cookies.info')%></p>
 
     <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-visually-hidden">
+        <%= t('cookie_settings.essential_cookies.table.caption')%>
+      </caption>
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col"><%= t('cookie_settings.essential_cookies.table.name')%></th>

--- a/app/views/about/cookies/index.html.erb
+++ b/app/views/about/cookies/index.html.erb
@@ -1,0 +1,111 @@
+<% title 'Cookies' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= render partial: 'shared/flash_banner',
+               locals: {
+                 flash: { success: t(".settings_updated.#{flash['cookies_consent_updated']}") }
+               } if flash['cookies_consent_updated'] %>
+
+    <h1 class="govuk-heading-xl">Cookies</h1>
+
+    <p class="govuk-body">The ‘<%= service_name %>’ service puts small files (known as ‘cookies’) onto your device to collect
+      information about how you use the service.</p>
+
+    <p class="govuk-body">You’ll normally see a message on the site before we set a cookie on your device.</p>
+
+    <p class="govuk-body">Cookies are not used to identify you personally.</p>
+
+    <p class="govuk-body">Find out
+      <a class="govuk-link" rel="external" target="_blank" href="https://ico.org.uk/for-the-public/online/cookies">how
+        to manage cookies</a> from the Information Commissioner’s Office.</p>
+
+    <h2 class="govuk-heading-l">Essential cookies (strictly necessary)</h2>
+
+    <p class="govuk-body">We use these cookies to remember your progress on this device and your cookie consent
+      settings.</p>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Name</th>
+        <th class="govuk-table__header">Purpose</th>
+        <th class="govuk-table__header">Expires</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">
+          _crm7restbackend_session
+        </th>
+        <td class="govuk-table__cell">
+          Saves your current progress on this device and tracks inactivity periods
+        </td>
+        <td class="govuk-table__cell">
+          When you close your browser
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">
+          <%= Rails.configuration.x.analytics.cookies_consent_name %>
+        </th>
+        <td class="govuk-table__cell">
+          Saves your cookie consent settings
+        </td>
+        <td class="govuk-table__cell">
+          After <%= Rails.configuration.x.analytics.cookies_consent_expiration.inspect %>
+        </td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">
+          <%= Rails.configuration.x.analytics.analytics_consent_name %>
+        </th>
+        <td class="govuk-table__cell">
+          Saves your analytics consent settings
+        </td>
+        <td class="govuk-table__cell">
+          After <%= Rails.configuration.x.analytics.analytics_consent_expiration.inspect %>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
+    <h2 class="govuk-heading-l">Analytics cookies (optional)</h2>
+    <p class="govuk-body">
+      We use Google Analytics software to collect information about how you use this service. We do this to help make sure
+      this service is meeting the needs of its users and to help us make improvements. Google Analytics stores information
+      about:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the pages you visit</li>
+      <li>how long you spend on each page</li>
+      <li>the device and browser you use</li>
+      <li>what you click on while you’re visiting the site</li>
+    </ul>
+
+    <p class="govuk-body">We do not allow Google to use or share our analytics data.</p>
+
+    <p class="govuk-body">We only set analytics cookies when:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you’ve accepted them</li>
+      <li>JavaScript is running in your browser</li>
+    </ul>
+
+    <p class="govuk-body"> If you choose not to run JavaScript we will only set essential cookies.</p>
+
+    <h3 class="govuk-heading-m govuk-!-margin-top-8">
+      Change your cookie settings
+    </h3>
+
+    <%= form_with model: @cookie, url: about_cookies_path, method: :put do |f| %>
+      <%= f.govuk_collection_radio_buttons :analytics,
+                                           [['true', t('cookie_settings.form.cookies_on')],
+                                            ['false', t('cookie_settings.form.cookies_off')]], :first,
+                                           :last,
+                                           legend: { text: t('cookie_settings.form.heading') },
+                                           hint: { text: t('cookie_settings.form.hint') } %>
+      <%= f.govuk_submit(t('cookie_settings.form.save_changes')) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_flash_banner.html.erb
+++ b/app/views/shared/_flash_banner.html.erb
@@ -10,7 +10,7 @@
     </div>
     <div class="govuk-notification-banner__content">
       <p class="govuk-notification-banner__heading">
-        <%= msg %>
+        <%= msg.html_safe %>
       </p>
     </div>
   </div>

--- a/app/views/shared/_flash_banner.html.erb
+++ b/app/views/shared/_flash_banner.html.erb
@@ -10,7 +10,7 @@
     </div>
     <div class="govuk-notification-banner__content">
       <p class="govuk-notification-banner__heading">
-        <%= msg.html_safe %>
+        <%= sanitize(msg, tags: %w[a]) %>
       </p>
     </div>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,9 @@ module Crm7restbackend
 
     config.x.contact.case_enquiries_tel = '0300 200 2020'
     config.x.contact.support_email = 'CRM457@digital.justice.gov.uk'
+    config.x.analytics.cookies_consent_name = 'cookies_preferences_set'
+    config.x.analytics.cookies_consent_expiration = 1.year
+    config.x.analytics.analytics_consent_name = 'analytics_preferences_set'
+    config.x.analytics.analytics_consent_expiration = 1.year
   end
 end

--- a/config/locales/en/cookies.yml
+++ b/config/locales/en/cookies.yml
@@ -7,6 +7,8 @@ en:
       heading: Turn Google Analytics cookies on or off
       hint: This is the same setting as set in the cookie banner
       save_changes: Save changes
+    notification_banner:
+      preferences_set_html: You've set your cookie preferences. <a class="govuk-notification-banner__link" href="%{href}">Go back to the page you were looking at</a>.
   layouts:
     application:
       cookies:

--- a/config/locales/en/cookies.yml
+++ b/config/locales/en/cookies.yml
@@ -7,3 +7,15 @@ en:
       heading: Turn Google Analytics cookies on or off
       hint: This is the same setting as set in the cookie banner
       save_changes: Save changes
+  layouts:
+    application:
+      cookies:
+        title: "Cookies on %{application}"
+        essential_cookies: We use some essential cookies to make this service work.
+        analytic_cookies: We’d also like to use analytics cookies so we can understand how you use the service and make improvements.
+        accept: Accept analytics cookies
+        reject: Reject analytics cookies
+        view: View cookies
+        confirmation_accepted: You’ve accepted additional cookies.
+        confirmation_rejected: You’ve rejected additional cookies.
+        link_to_settings: You can <a class="govuk-link" href="%{href}" data-turbo="false">change your cookie settings</a> at any time.

--- a/config/locales/en/cookies.yml
+++ b/config/locales/en/cookies.yml
@@ -1,0 +1,9 @@
+---
+en:
+  cookie_settings:
+    form:
+      cookies_off: 'Off'
+      cookies_on: 'On'
+      heading: Turn Google Analytics cookies on or off
+      hint: This is the same setting as set in the cookie banner
+      save_changes: Save changes

--- a/config/locales/en/cookies.yml
+++ b/config/locales/en/cookies.yml
@@ -1,6 +1,43 @@
 ---
 en:
   cookie_settings:
+    title: Cookies
+    heading: Cookies
+    paragraph_1: "The ‘%{service}’ service puts small files (known as ‘cookies’) onto your device to collect
+      information about how you use the service."
+    paragraph_2: You’ll normally see a message on the site before we set a cookie on your device.
+    paragraph_3: Cookies are not used to identify you personally.
+    paragraph_4: Find out <a class="govuk-link" rel="external" target="_blank" href="https://ico.org.uk/for-the-public/online/cookies">how to manage cookies</a> from the Information Commissioner’s Office.
+    essential_cookies:
+      heading: Essential cookies (strictly necessary)
+      info: We use these cookies to remember your progress on this device and your cookie consent settings.
+      table:
+        name: Name
+        purpose: Purpose
+        expires: Expires
+        row:
+          name_1: _crm7restbackend_session
+          purpose_1: Saves your current progress on this device and tracks inactivity periods
+          expires_1: When you close your browser
+          purpose_2: Saves your cookie consent settings
+          purpose_3: Saves your analytics consent settings
+    analytics_cookies:
+      heading: Analytics cookies (optional)
+      info: "We use Google Analytics software to collect information about how you use this service. We do this to help make sure
+      this service is meeting the needs of its users and to help us make improvements. Google Analytics stores information about:"
+      list_1:
+        item_1: the pages you visit
+        item_2: how long you spend on each page
+        item_3: the device and browser you use
+        item_4: what you click on while you’re visiting the site
+      paragraph_1: We do not allow Google to use or share our analytics data.
+      paragraph_2: "We only set analytics cookies when:"
+      list_2:
+        item_1: you’ve accepted them
+        item_2: JavaScript is running in your browser
+      paragraph_3: If you choose not to run JavaScript we will only set essential cookies.
+      change_settings_heading: Change your cookie settings
+
     form:
       cookies_off: 'Off'
       cookies_on: 'On'

--- a/config/locales/en/cookies.yml
+++ b/config/locales/en/cookies.yml
@@ -12,6 +12,7 @@ en:
       heading: Essential cookies (strictly necessary)
       info: We use these cookies to remember your progress on this device and your cookie consent settings.
       table:
+        caption: Cookies tracked by this application
         name: Name
         purpose: Purpose
         expires: Expires

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
   namespace :about do
     resources :feedback, only: [:index, :create]
+    resources :cookies, only: [:index, :update]
     get :privacy
     get :contact
     get :accessibility

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,8 @@ Rails.application.routes.draw do
 
   namespace :about do
     resources :feedback, only: [:index, :create]
-    resources :cookies, only: [:index, :update]
+    resources :cookies, only: [:index, :create]
+    get :update_cookies
     get :privacy
     get :contact
     get :accessibility

--- a/gems/laa_multi_step_forms/app/views/layouts/_analytics.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/_analytics.html.erb
@@ -1,0 +1,8 @@
+<%= javascript_include_tag "https://www.googletagmanager.com/gtag/js?id=#{ENV.fetch('ANALYTICS_TRACKING_ID', nil)}", async: true, nonce: true %>
+
+<%= javascript_tag nonce: true do %>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', <%== ENV.fetch('ANALYTICS_TRACKING_ID', nil).to_json %>, { 'anonymize_ip': true, 'allow_google_signals': false });
+<% end %>

--- a/gems/laa_multi_step_forms/app/views/layouts/_analytics.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/_analytics.html.erb
@@ -1,8 +1,13 @@
-<%= javascript_include_tag "https://www.googletagmanager.com/gtag/js?id=#{ENV.fetch('ANALYTICS_TRACKING_ID', nil)}", async: true, nonce: true %>
+<% if @analytics_cookies_accepted %>
+  <%= javascript_include_tag "https://www.googletagmanager.com/gtag/js?id=#{@analytics_cookies_accepted ?
+                                                                              ENV.fetch('ANALYTICS_TRACKING_ID', nil)
+                                                                              : nil}", async: true, nonce: true %>
 
-<%= javascript_tag nonce: true do %>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', <%== ENV.fetch('ANALYTICS_TRACKING_ID', nil).to_json %>, { 'anonymize_ip': true, 'allow_google_signals': false });
+  <%= javascript_tag nonce: true do %>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', <%== @analytics_cookies_accepted ? ENV.fetch('ANALYTICS_TRACKING_ID', nil).to_json : nil %>,
+    { 'anonymize_ip': true, 'allow_google_signals': false });
+  <% end %>
 <% end %>

--- a/gems/laa_multi_step_forms/app/views/layouts/_footer_links.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/_footer_links.html.erb
@@ -4,7 +4,7 @@
   <li class="govuk-footer__inline-list-item">
     <%# Destination needs validating %>
 
-    <%= link_to 'Cookies', 'https://www.gov.uk/help/cookies', class: 'govuk-footer__link' %>
+    <%= link_to 'Cookies', main_app.about_cookies_path, class: 'govuk-footer__link' %>
   </li>
 
   <li class="govuk-footer__inline-list-item">

--- a/gems/laa_multi_step_forms/app/views/layouts/application.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/application.html.erb
@@ -3,6 +3,11 @@
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <%= render partial: 'layouts/analytics' if @analytics_cookies_accepted %>
+<% end %>
+
+<% content_for(:cookie_banner) do %>
+  <% render partial: 'layouts/cookie_banner/main', locals: { cookies_preferences_set: @cookies_preferences_set } %>
 <% end %>
 
 <% content_for(:service_name) do %>

--- a/gems/laa_multi_step_forms/app/views/layouts/application.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/application.html.erb
@@ -3,11 +3,14 @@
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <%= render partial: 'layouts/analytics' if @analytics_cookies_accepted %>
+<% end %>
+
+<% content_for(:analytics) do %>
+  <%= render partial: 'layouts/analytics' %>
 <% end %>
 
 <% content_for(:cookie_banner) do %>
-  <% render partial: 'layouts/cookie_banner/main', locals: { cookies_preferences_set: @cookies_preferences_set } %>
+  <% render partial: 'layouts/cookie_banner/main', locals: { cookies_preferences_set: @cookie_preferences_set } %>
 <% end %>
 
 <% content_for(:service_name) do %>

--- a/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_hide.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_hide.html.erb
@@ -1,1 +1,1 @@
-<turbo-frame id="removable"></turbo-frame>
+<%= turbo_frame_tag :removable %>

--- a/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_hide.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_hide.html.erb
@@ -1,0 +1,1 @@
+<turbo-frame id="removable"></turbo-frame>

--- a/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_main.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_main.html.erb
@@ -1,20 +1,24 @@
 <% unless cookies_preferences_set -%>
   <%= turbo_frame_tag :removable do %>
-    <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on <%=Rails.configuration.x.application.name %>">
+    <div class="govuk-cookie-banner " data-nosnippet role="region"
+         aria-label="<%= t('layouts.application.cookies.title', application: Rails.configuration.x.application.name) %>">
       <div class="govuk-cookie-banner__message govuk-width-container">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on <%= Rails.configuration.x.application.name %></h2>
+            <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+              <%= t('layouts.application.cookies.title', application: Rails.configuration.x.application.name) %></h2>
             <div class="govuk-cookie-banner__content">
-              <p class="govuk-body">We use some essential cookies to make this service work.</p>
-              <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+              <p class="govuk-body"><%= t('layouts.application.cookies.essential_cookies') %></p>
+              <p class="govuk-body"><%= t('layouts.application.cookies.analytic_cookies') %></p>
             </div>
           </div>
         </div>
         <div class="govuk-button-group">
-          <%= govuk_link_to "Accept analytics cookies", main_app.about_update_cookies_path(cookies_preference:true), class: 'govuk-button', 'data-module': 'govuk-button' %>
-          <%= govuk_link_to "Reject analytics cookies", main_app.about_update_cookies_path(cookies_preference:false), class: 'govuk-button', 'data-module': 'govuk-button' %>
-          <%= govuk_link_to 'View cookies', main_app.about_cookies_path %>
+          <%= govuk_link_to t('layouts.application.cookies.accept'), main_app.about_update_cookies_path(cookies_preference:true),
+                            class: 'govuk-button', 'data-module': 'govuk-button', 'data-accept-cookies': 'true' %>
+          <%= govuk_link_to t('layouts.application.cookies.reject'), main_app.about_update_cookies_path(cookies_preference:false),
+                            class: 'govuk-button', 'data-module': 'govuk-button', 'data-reject-cookies': 'true' %>
+          <%= govuk_link_to t('layouts.application.cookies.view'), main_app.about_cookies_path %>
         </div>
       </div>
     </div>

--- a/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_main.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_main.html.erb
@@ -1,0 +1,22 @@
+<% unless cookies_preferences_set -%>
+  <turbo-frame id="removeable">
+    <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on <%=Rails.configuration.x.application.name %>">
+      <div class="govuk-cookie-banner__message govuk-width-container">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on <%= Rails.configuration.x.application.name %></h2>
+            <div class="govuk-cookie-banner__content">
+              <p class="govuk-body">We use some essential cookies to make this service work.</p>
+              <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+            </div>
+          </div>
+        </div>
+        <div class="govuk-button-group">
+          <%= govuk_link_to "Accept analytics cookies", main_app.about_update_cookies_path(cookies_preference:true), class: 'govuk-button', 'data-module': 'govuk-button' %>
+          <%= govuk_link_to "Reject analytics cookies", main_app.about_update_cookies_path(cookies_preference:false), class: 'govuk-button', 'data-module': 'govuk-button' %>
+          <%= govuk_link_to 'View cookies', main_app.about_cookies_path %>
+        </div>
+      </div>
+    </div>
+  </turbo-frame>
+<% end %>

--- a/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_main.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_main.html.erb
@@ -1,5 +1,5 @@
 <% unless cookies_preferences_set -%>
-  <turbo-frame id="removeable">
+  <%= turbo_frame_tag :removable do %>
     <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on <%=Rails.configuration.x.application.name %>">
       <div class="govuk-cookie-banner__message govuk-width-container">
         <div class="govuk-grid-row">
@@ -18,5 +18,5 @@
         </div>
       </div>
     </div>
-  </turbo-frame>
+  <% end %>
 <% end %>

--- a/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_success.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_success.html.erb
@@ -1,0 +1,23 @@
+<turbo-frame id="removeable">
+  <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on <%=Rails.configuration.x.application.name %>">
+    <div class="govuk-cookie-banner__message govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-cookie-banner__content">
+            <%= if @analytics_cookies_accepted %>
+              <p class="govuk-body">You’ve accepted additional cookies. You can <%= govuk_link_to 'change your cookie settings', main_app.about_cookies_path %> at any time.</p>
+            <%= else %>
+              <p class="govuk-body">You’ve rejected additional cookies. You can <%= govuk_link_to 'change your cookie settings', main_app.about_cookies_path %> at any time.</p>
+            <%= end %>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        <%= govuk_link_to 'Hide this message', 'data-module': 'govuk-button', type: 'button', draggable: 'false', 'href': main_app.about_update_cookies_path(hide_banner: true) %>
+        <button value="yes" type="submit" name="cookies[hide]" class="govuk-button" data-module="govuk-button">
+          Hide cookie message
+        </button>
+      </div>
+    </div>
+  </div>
+</turbo-frame>

--- a/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_success.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_success.html.erb
@@ -4,16 +4,10 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="govuk-cookie-banner__content">
-            <%= @analytics_cookies_accepted ? 'Accepted' : 'Rejected' %>
-<!--              <p>Accepted</p>-->
-<!--              <p class="govuk-body">You’ve accepted additional cookies. You-->
-<!--                can <%= govuk_link_to 'change your cookie settings', main_app.about_cookies_path %> at any time.</p>-->
-            <%#= end %>
-            <%#= unless @analytics_cookies_accepted %>
-<!--              <p>Rejected</p>-->
-<!--            <p class="govuk-body">You’ve rejected additional cookies. You-->
-<!--              can <%= govuk_link_to 'change your cookie settings', main_app.about_cookies_path %> at any time.</p>-->
-            <%#= end %>
+            <p class="govuk-body">
+              <%= @analytics_cookies_accepted ? t('layouts.application.cookies.confirmation_accepted') : t('layouts.application.cookies.confirmation_rejected') %>
+              <%= t('layouts.application.cookies.link_to_settings', href: main_app.about_cookies_path).html_safe %>
+            </p>
           </div>
         </div>
       </div>

--- a/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_success.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/cookie_banner/_success.html.erb
@@ -1,23 +1,25 @@
-<turbo-frame id="removeable">
+<%= turbo_frame_tag :removable do %>
   <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on <%=Rails.configuration.x.application.name %>">
     <div class="govuk-cookie-banner__message govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <div class="govuk-cookie-banner__content">
-            <%= if @analytics_cookies_accepted %>
-              <p class="govuk-body">You’ve accepted additional cookies. You can <%= govuk_link_to 'change your cookie settings', main_app.about_cookies_path %> at any time.</p>
-            <%= else %>
-              <p class="govuk-body">You’ve rejected additional cookies. You can <%= govuk_link_to 'change your cookie settings', main_app.about_cookies_path %> at any time.</p>
-            <%= end %>
+            <%= @analytics_cookies_accepted ? 'Accepted' : 'Rejected' %>
+<!--              <p>Accepted</p>-->
+<!--              <p class="govuk-body">You’ve accepted additional cookies. You-->
+<!--                can <%= govuk_link_to 'change your cookie settings', main_app.about_cookies_path %> at any time.</p>-->
+            <%#= end %>
+            <%#= unless @analytics_cookies_accepted %>
+<!--              <p>Rejected</p>-->
+<!--            <p class="govuk-body">You’ve rejected additional cookies. You-->
+<!--              can <%= govuk_link_to 'change your cookie settings', main_app.about_cookies_path %> at any time.</p>-->
+            <%#= end %>
           </div>
         </div>
       </div>
       <div class="govuk-button-group">
-        <%= govuk_link_to 'Hide this message', 'data-module': 'govuk-button', type: 'button', draggable: 'false', 'href': main_app.about_update_cookies_path(hide_banner: true) %>
-        <button value="yes" type="submit" name="cookies[hide]" class="govuk-button" data-module="govuk-button">
-          Hide cookie message
-        </button>
+        <%= govuk_link_to "Hide this message", main_app.about_update_cookies_path(hide_banner: true), class: 'govuk-button', 'data-module': 'govuk-button' %>
       </div>
     </div>
   </div>
-</turbo-frame>
+<% end %>

--- a/gems/laa_multi_step_forms/app/views/layouts/govuk_template.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/govuk_template.html.erb
@@ -22,6 +22,7 @@
   <%= javascript_importmap_tags %>
 
   <%= yield :head %>
+  <%= yield :analytics if @analytics_cookies_accepted %>
 </head>
 
 <body class="govuk-template__body <%= app_environment %>">

--- a/gems/laa_multi_step_forms/app/views/layouts/govuk_template.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/govuk_template.html.erb
@@ -25,6 +25,7 @@
 </head>
 
 <body class="govuk-template__body <%= app_environment %>">
+<%= yield(:cookie_banner)%>
 <script>
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>

--- a/spec/controllers/about/cookie_controller_spec.rb
+++ b/spec/controllers/about/cookie_controller_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe About::CookiesController do
+  describe '#cookies' do
+    context 'index' do
+      context 'analytics disabled' do
+        before do
+          get :index
+        end
+
+        it 'has a 200 response code' do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context 'analytics enabled' do
+        before do
+          request.cookies['analytics_cookies_set'] = true
+          get :index
+        end
+
+        it 'has a 200 response code' do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context 'create' do
+      before do
+        post :create, params: cookie_params
+      end
+
+      context 'accept analytics' do
+        let(:cookie_params) do
+          { cookie: {'analytics' => 'true' } }
+        end
+
+        it 'has a 200 response code' do
+          expect(response).to redirect_to(about_cookies_path)
+        end
+
+        it 'should return the cookie set to true' do
+          expect(response.cookies).to include { 'analytics_cookies_set' => 'true' }
+        end
+
+        it 'flashes notice' do
+          expect(flash.now[:success]).to match("You've set your cookie preferences. <a class=\"govuk-notification-banner__link\" href=\"\">Go back to the page you were looking at</a>.")
+        end
+      end
+
+      context 'reject analytics' do
+        let(:cookie_params) do
+          { cookie: {'analytics' => 'false' } }
+        end
+
+        it 'has a 200 response code' do
+          expect(response).to redirect_to(about_cookies_path)
+        end
+
+        it 'should return the cookie set to false' do
+          expect(response.cookies).to include { 'analytics_cookies_set' => 'false' }
+        end
+
+        it 'flashes notice' do
+          expect(flash.now[:success]).to match("You've set your cookie preferences. <a class=\"govuk-notification-banner__link\" href=\"\">Go back to the page you were looking at</a>.")
+        end
+      end
+
+      context 'bad value' do
+        let(:cookie_params) do
+          { cookie: {'analytics' => ';-- select * from users;' } }
+        end
+
+        it 'redirect to cookies path' do
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/about/cookie_controller_spec.rb
+++ b/spec/controllers/about/cookie_controller_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe About::CookiesController do
         end
 
         it 'flashes notice' do
-          expect(flash.now[:success]).to match("You've set your cookie preferences. <a class=\"govuk-notification-banner__link\" href=\"\">Go back to the page you were looking at</a>.")
+          expect(flash.now[:success]).to match("You've set your cookie preferences.
+<a class=\"govuk-notification-banner__link\" href=\"\">Go back to the page you were looking at</a>.")
         end
       end
 
@@ -62,7 +63,8 @@ RSpec.describe About::CookiesController do
         end
 
         it 'flashes notice' do
-          expect(flash.now[:success]).to match("You've set your cookie preferences. <a class=\"govuk-notification-banner__link\" href=\"\">Go back to the page you were looking at</a>.")
+          expect(flash.now[:success]).to match("You've set your cookie preferences.
+<a class=\"govuk-notification-banner__link\" href=\"\">Go back to the page you were looking at</a>.")
         end
       end
 

--- a/spec/controllers/about/cookie_controller_spec.rb
+++ b/spec/controllers/about/cookie_controller_spec.rb
@@ -32,15 +32,15 @@ RSpec.describe About::CookiesController do
 
       context 'accept analytics' do
         let(:cookie_params) do
-          { cookie: {'analytics' => 'true' } }
+          { cookie: { 'analytics' => 'true' } }
         end
 
         it 'has a 200 response code' do
           expect(response).to redirect_to(about_cookies_path)
         end
 
-        it 'should return the cookie set to true' do
-          expect(response.cookies).to include { 'analytics_cookies_set' => 'true' }
+        it 'returns the cookie set to true' do
+          expect(response.cookies).to(include { 'analytics_cookies_set' => 'true' })
         end
 
         it 'flashes notice' do
@@ -50,15 +50,15 @@ RSpec.describe About::CookiesController do
 
       context 'reject analytics' do
         let(:cookie_params) do
-          { cookie: {'analytics' => 'false' } }
+          { cookie: { 'analytics' => 'false' } }
         end
 
         it 'has a 200 response code' do
           expect(response).to redirect_to(about_cookies_path)
         end
 
-        it 'should return the cookie set to false' do
-          expect(response.cookies).to include { 'analytics_cookies_set' => 'false' }
+        it 'returns the cookie set to false' do
+          expect(response.cookies).to(include { 'analytics_cookies_set' => 'false' })
         end
 
         it 'flashes notice' do
@@ -68,7 +68,7 @@ RSpec.describe About::CookiesController do
 
       context 'bad value' do
         let(:cookie_params) do
-          { cookie: {'analytics' => ';-- select * from users;' } }
+          { cookie: { 'analytics' => ';-- select * from users;' } }
         end
 
         it 'redirect to cookies path' do

--- a/spec/controllers/about/cookie_controller_spec.rb
+++ b/spec/controllers/about/cookie_controller_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe About::CookiesController do
         end
 
         it 'flashes notice' do
-          expect(flash.now[:success]).to match("You've set your cookie preferences.
-<a class=\"govuk-notification-banner__link\" href=\"\">Go back to the page you were looking at</a>.")
+          expect(flash.now[:success]).to match(/You've set your cookie preferences./)
         end
       end
 
@@ -63,8 +62,7 @@ RSpec.describe About::CookiesController do
         end
 
         it 'flashes notice' do
-          expect(flash.now[:success]).to match("You've set your cookie preferences.
-<a class=\"govuk-notification-banner__link\" href=\"\">Go back to the page you were looking at</a>.")
+          expect(flash.now[:success]).to match(/You've set your cookie preferences./)
         end
       end
 

--- a/spec/controllers/concern/cookie_concern_spec.rb
+++ b/spec/controllers/concern/cookie_concern_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe About::CookiesController, type: :request do
           get '/about/update_cookies', params: { cookies_preference: true }
         end
 
-        it 'should render success partial' do
-          expect(response).to render_template(:partial => 'layouts/cookie_banner/_success')
+        it 'renders success partial' do
+          expect(response).to render_template(partial: 'layouts/cookie_banner/_success')
         end
 
-        it 'should render success partial' do
+        it 'renders success partial' do
           expect(response.body).to match(/You’ve accepted additional cookies./)
         end
       end
@@ -22,11 +22,11 @@ RSpec.describe About::CookiesController, type: :request do
           get '/about/update_cookies', params: { cookies_preference: false }
         end
 
-        it 'should render success partial' do
-          expect(response).to render_template(:partial => 'layouts/cookie_banner/_success')
+        it 'renders success partial' do
+          expect(response).to render_template(partial: 'layouts/cookie_banner/_success')
         end
 
-        it 'should render success partial' do
+        it 'renders success partial' do
           expect(response.body).to match(/You’ve rejected additional cookies./)
         end
       end
@@ -37,8 +37,8 @@ RSpec.describe About::CookiesController, type: :request do
         get '/about/update_cookies', params: { hide_banner: true }
       end
 
-      it 'should render success partial' do
-        expect(response).to render_template(:partial => 'layouts/cookie_banner/_hide')
+      it 'renders success partial' do
+        expect(response).to render_template(partial: 'layouts/cookie_banner/_hide')
       end
     end
   end

--- a/spec/controllers/concern/cookie_concern_spec.rb
+++ b/spec/controllers/concern/cookie_concern_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe About::CookiesController, type: :request do
+  context 'update_cookies' do
+    context 'update analytics' do
+      context 'accept' do
+        before do
+          get '/about/update_cookies', params: { cookies_preference: true }
+        end
+
+        it 'should render success partial' do
+          expect(response).to render_template(:partial => 'layouts/cookie_banner/_success')
+        end
+
+        it 'should render success partial' do
+          expect(response.body).to match(/You’ve accepted additional cookies./)
+        end
+      end
+
+      context 'reject' do
+        before do
+          get '/about/update_cookies', params: { cookies_preference: false }
+        end
+
+        it 'should render success partial' do
+          expect(response).to render_template(:partial => 'layouts/cookie_banner/_success')
+        end
+
+        it 'should render success partial' do
+          expect(response.body).to match(/You’ve rejected additional cookies./)
+        end
+      end
+    end
+
+    context 'hide banner' do
+      before do
+        get '/about/update_cookies', params: { hide_banner: true }
+      end
+
+      it 'should render success partial' do
+        expect(response).to render_template(:partial => 'layouts/cookie_banner/_hide')
+      end
+    end
+  end
+end

--- a/spec/controllers/concern/cookie_concern_spec.rb
+++ b/spec/controllers/concern/cookie_concern_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe About::CookiesController, type: :request do
           expect(response).to render_template(partial: 'layouts/cookie_banner/_success')
         end
 
-        it 'renders success partial' do
+        it 'renders success message' do
           expect(response.body).to match(/You’ve accepted additional cookies./)
         end
       end
@@ -26,7 +26,7 @@ RSpec.describe About::CookiesController, type: :request do
           expect(response).to render_template(partial: 'layouts/cookie_banner/_success')
         end
 
-        it 'renders success partial' do
+        it 'renders reject message' do
           expect(response.body).to match(/You’ve rejected additional cookies./)
         end
       end
@@ -37,7 +37,7 @@ RSpec.describe About::CookiesController, type: :request do
         get '/about/update_cookies', params: { hide_banner: true }
       end
 
-      it 'renders success partial' do
+      it 'renders hide partial' do
         expect(response).to render_template(partial: 'layouts/cookie_banner/_hide')
       end
     end

--- a/spec/system/disbursement_type/suggestion_autocomplete_spec.rb
+++ b/spec/system/disbursement_type/suggestion_autocomplete_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe 'Test suggestion autocomplete for court', :javascript, type: :sys
   let(:claim) { create(:claim) }
   let(:other_type_field) { 'steps_disbursement_type_form[other_type_suggestion]' }
 
-  it 'can select a value from the autocomplete' do
+  before do
     visit provider_saml_omniauth_callback_path
+    click_link 'Accept analytics cookies'
+  end
 
+  it 'can select a value from the autocomplete' do
     visit edit_steps_disbursement_add_path(id: claim)
 
     choose 'Yes', visible: :all
@@ -28,8 +31,6 @@ RSpec.describe 'Test suggestion autocomplete for court', :javascript, type: :sys
   end
 
   it 'can enter a value not found in the autocoplete' do
-    visit provider_saml_omniauth_callback_path
-
     visit edit_steps_disbursement_add_path(id: claim)
 
     choose 'Yes', visible: :all

--- a/spec/system/hearing_details/suggestion_autocomplete_spec.rb
+++ b/spec/system/hearing_details/suggestion_autocomplete_spec.rb
@@ -3,9 +3,12 @@ require 'system_helper'
 RSpec.describe 'Test suggestion autocomplete for court', :javascript, type: :system do
   let(:claim) { create(:claim, :case_details) }
 
-  it 'can select a value from the autocomplete' do
+  before do
     visit provider_saml_omniauth_callback_path
+    click_link 'Accept analytics cookies'
+  end
 
+  it 'can select a value from the autocomplete' do
     visit edit_steps_case_details_path(id: claim)
 
     click_on 'Save and continue'
@@ -21,8 +24,6 @@ RSpec.describe 'Test suggestion autocomplete for court', :javascript, type: :sys
   end
 
   it 'can enter a value not found in the autocoplete' do
-    visit provider_saml_omniauth_callback_path
-
     visit edit_steps_case_details_path(id: claim)
 
     click_on 'Save and continue'


### PR DESCRIPTION
## Description of change

- Adds Turbo for inline cookie banner interactivity (This is opt-in to not break existing functionality
- Adds cookie banner with translation files
- Adds cookie concern to support
- Add partial for Google Analytics
- Adds and updates tests

## Link to relevant ticket

[CRM457-645](https://dsdmoj.atlassian.net/browse/CRM457-645)

## Notes for reviewer

First view of website will display cookie banner until accepted/rejected. To view again delete cookies

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-645]: https://dsdmoj.atlassian.net/browse/CRM457-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ