### PR TITLE
CRM457-675 - Update disbursement types for output

### DIFF
--- a/app/forms/steps/disbursement_cost_form.rb
+++ b/app/forms/steps/disbursement_cost_form.rb
@@ -80,6 +80,7 @@ module Steps
         'miles' => other_disbursement_type? ? nil : miles,
         'total_cost_without_vat' => total_cost_pre_vat,
         'vat_amount' => vat,
+        'apply_vat' => apply_vat ? 'true' : 'false'
       )
     end
 

--- a/app/services/notify_app_store/message_builder.rb
+++ b/app/services/notify_app_store/message_builder.rb
@@ -44,6 +44,8 @@ class NotifyAppStore
         data['disbursement_date'] = data['disbursement_date'].to_s
         data['pricing'] = pricing[disbursement.disbursement_type] || 1.0
         data['vat_rate'] = pricing[:vat]
+        data['vat_amount'] = data['vat_amount'].to_f
+        data['total_cost_without_vat'] = data['total_cost_without_vat'].to_f
         data
       end
     end

--- a/app/services/notify_app_store/message_builder.rb
+++ b/app/services/notify_app_store/message_builder.rb
@@ -36,7 +36,6 @@ class NotifyAppStore
         'supporting_evidences' => supporting_evidence
       )
     end
-    # rubocop:enable Metrics/AbcSize
 
     def disbursement_data
       claim.disbursements.map do |disbursement|
@@ -49,6 +48,7 @@ class NotifyAppStore
         data
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def work_item_data
       claim.work_items.map do |work_item|

--- a/spec/factories/disbursements.rb
+++ b/spec/factories/disbursements.rb
@@ -14,8 +14,9 @@ FactoryBot.define do
       total_cost_without_vat do |disb|
         Pricing.for(Claim.new)[disb.disbursement_type] * disb.miles
       end
+      vat_amount { total_cost_without_vat * 0.2 }
       details { 'Details' }
-      apply_vat { 'no' }
+      apply_vat { 'true' }
     end
 
     trait :valid_type do
@@ -29,7 +30,7 @@ FactoryBot.define do
       other_type { OtherDisbursementTypes.values.sample }
       total_cost_without_vat { 90.0 }
       details { 'Details' }
-      apply_vat { 'yes' }
+      apply_vat { 'true' }
     end
 
     trait :valid_other_specific do
@@ -38,7 +39,7 @@ FactoryBot.define do
       other_type { OtherDisbursementTypes.values[0] }
       total_cost_without_vat { 90.0 }
       details { 'Details' }
-      apply_vat { 'yes' }
+      apply_vat { 'true' }
     end
 
     trait :valid_high_cost do
@@ -47,13 +48,13 @@ FactoryBot.define do
       other_type { OtherDisbursementTypes.values[0] }
       total_cost_without_vat { 5000.1 }
       details { 'Details' }
-      apply_vat { 'yes' }
+      apply_vat { 'true' }
     end
 
     trait :authed do
       total_cost_without_vat { 100.0 }
       details { 'Details' }
-      prior_authority { 'yes' }
+      prior_authority { 'true' }
     end
 
     trait :partial do

--- a/spec/services/notify_app_store/message_builder_spec.rb
+++ b/spec/services/notify_app_store/message_builder_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe NotifyAppStore::MessageBuilder do
           'disability' => nil,
           'disbursements' =>
           [{
-            'apply_vat' => 'no',
+            'apply_vat' => 'true',
             'details' => 'Details',
             'disbursement_date' => '2023-08-16',
             'disbursement_type' => { en: an_instance_of(String), value: disbursement.disbursement_type },
@@ -49,8 +49,8 @@ RSpec.describe NotifyAppStore::MessageBuilder do
             'other_type' => { en: nil, value: nil },
             'pricing' => pricing[disbursement.disbursement_type],
             'prior_authority' => nil,
-            'total_cost_without_vat' => disbursement.total_cost_without_vat.to_s,
-            'vat_amount' => nil,
+            'total_cost_without_vat' => disbursement.total_cost_without_vat.to_f,
+            'vat_amount' => disbursement.vat_amount.to_f,
             'vat_rate' => 0.2
           }],
           'ethnic_group' => nil,

--- a/spec/steps/cost_summary/integration_spec.rb
+++ b/spec/steps/cost_summary/integration_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe 'User can see cost breakdowns', type: :system do
         'Phone calls', '£12.27', # 4.09 * 3
         'Total', '£20.45',
 
-        'Disbursements total £227.50',
+        'Disbursements total £259.00',
         'Items', 'Total per item',
-        'Car', '£90.00', # 200 * 0.45
+        'Car', '£108.00',
         'DNA Testing', '£30.00',
         'Custom', '£40.00',
-        'Car', '£67.50', # 150 * 0.45
-        'Total', '£227.50'
+        'Car', '£81.00',
+        'Total', '£259.00'
       ]
     )
   end


### PR DESCRIPTION
## Description of change

- Save apply_vat flag and return
- return float and not string for values

## Link to relevant ticket

[CRM457-675](https://dsdmoj.atlassian.net/browse/CRM457-675)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-675]: https://dsdmoj.atlassian.net/browse/CRM457-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ