### PR TITLE
CRM457-687 - Update and add Status card

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server -p 3000
 css: bin/rails dartsass:watch
+sidekiq: DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -41,6 +41,12 @@ class Claim < ApplicationRecord
     end
   end
 
+  def translate_plea
+    {
+      'plea' => translations(plea, 'helpers.label.steps_case_disposal_form.plea_options')
+    }
+  end
+
   def translated_letters_and_calls
     pricing = Pricing.for(self)
     [
@@ -69,6 +75,7 @@ class Claim < ApplicationRecord
         'matter_type' => matter_type_name,
         'reasons_for_claim' => translated_reasons_for_claim,
         'hearing_outcome' => hearing_outcome_name,
+        **translate_plea,
         **translated_equality_answers
       ).slice!('letters', 'letters_uplift', 'calls', 'calls_uplift', 'app_store_updated_at')
   end

--- a/app/presenters/check_answers/application_status_card.rb
+++ b/app/presenters/check_answers/application_status_card.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module CheckAnswers
+  class ApplicationStatusCard < Base
+    attr_reader :claim
+
+    def initialize(claim)
+      @claim = claim
+      @group = 'application_status'
+      @section = 'application_status'
+    end
+
+    def row_data
+      [
+        {
+          head_key: 'application_status',
+          text: "<strong class=\"govuk-tag .status_colour.#{claim.status}\">#{I18n.t("claims.index.status.#{claim.status}")}</strong>".html_safe
+        },
+        date_actioned_row
+      ].compact
+    end
+
+    private
+
+    def date_actioned_row
+      {
+        head_key: get_date_actioned_head,
+        text: claim.updated_at.strftime('%d %B %Y')
+      }
+    end
+
+    def get_date_actioned_head
+      case claim.status
+      when 'submitted'
+        I18n.t('steps.check_answers.show.sections.application_status.submitted')
+      when 'granted' || 'part_granted'
+        I18n.t('steps.check_answers.show.sections.application_status.assessed')
+      else
+        I18n.t('steps.check_answers.show.sections.application_status.returned')
+      end
+    end
+  end
+end

--- a/app/presenters/check_answers/application_status_card.rb
+++ b/app/presenters/check_answers/application_status_card.rb
@@ -36,7 +36,7 @@ module CheckAnswers
         I18n.t('steps.check_answers.show.sections.application_status.submitted')
       when 'granted'
         I18n.t('steps.check_answers.show.sections.application_status.granted')
-      when 'part_granted'
+      when 'part_grant'
         I18n.t('steps.check_answers.show.sections.application_status.part_granted')
       else
         I18n.t('steps.check_answers.show.sections.application_status.returned')

--- a/app/presenters/check_answers/application_status_card.rb
+++ b/app/presenters/check_answers/application_status_card.rb
@@ -14,7 +14,8 @@ module CheckAnswers
       [
         {
           head_key: 'application_status',
-          text: "<strong class=\"govuk-tag .status_colour.#{claim.status}\">#{I18n.t("claims.index.status.#{claim.status}")}</strong>".html_safe
+          text: "<strong class=\"govuk-tag #{I18n.t("claims.index.status_colour.#{claim.status}")}\">
+                  #{I18n.t("claims.index.status.#{claim.status}")}</strong>".html_safe
         },
         date_actioned_row
       ].compact
@@ -24,17 +25,19 @@ module CheckAnswers
 
     def date_actioned_row
       {
-        head_key: get_date_actioned_head,
-        text: claim.updated_at.strftime('%d %B %Y')
+        head_key: date_actioned_head,
+        text: claim.updated_at&.strftime('%d %B %Y')
       }
     end
 
-    def get_date_actioned_head
+    def date_actioned_head
       case claim.status
       when 'submitted'
         I18n.t('steps.check_answers.show.sections.application_status.submitted')
-      when 'granted' || 'part_granted'
-        I18n.t('steps.check_answers.show.sections.application_status.assessed')
+      when 'granted'
+        I18n.t('steps.check_answers.show.sections.application_status.granted')
+      when 'part_granted'
+        I18n.t('steps.check_answers.show.sections.application_status.part_granted')
       else
         I18n.t('steps.check_answers.show.sections.application_status.returned')
       end

--- a/app/presenters/check_answers/application_status_card.rb
+++ b/app/presenters/check_answers/application_status_card.rb
@@ -14,8 +14,8 @@ module CheckAnswers
       [
         {
           head_key: 'application_status',
-          text: "<strong class=\"govuk-tag #{I18n.t("claims.index.status_colour.#{claim.status}")}\">
-                  #{I18n.t("claims.index.status.#{claim.status}")}</strong>".html_safe
+          text: "<strong class=\"govuk-tag #{I18n.t("claims.index.status_colour.#{claim.status}")}\">" \
+                "#{I18n.t("claims.index.status.#{claim.status}")}</strong>".html_safe
         },
         date_actioned_row
       ].compact

--- a/app/presenters/check_answers/read_only_report.rb
+++ b/app/presenters/check_answers/read_only_report.rb
@@ -3,6 +3,7 @@ module CheckAnswers
     include GovukLinkHelper
     include ActionView::Helpers::UrlHelper
     GROUPS = %w[
+      application_status
       claim_type
       about_you
       about_defendant
@@ -41,6 +42,10 @@ module CheckAnswers
           rows: data.rows
         }
       end
+    end
+
+    def application_status_section
+      [ApplicationStatusCard.new(claim)]
     end
 
     def claim_type_section

--- a/config/locales/en/check_answers.yml
+++ b/config/locales/en/check_answers.yml
@@ -10,7 +10,8 @@ en:
             application_status: Status
             status: Status
             submitted: Date Submitted
-            assessed: Date Assessed
+            granted: Date Assessed
+            part_granted: Date Assessed
             returned: Date Returned
           claim_type:
             file_ufn: Unique file number

--- a/config/locales/en/check_answers.yml
+++ b/config/locales/en/check_answers.yml
@@ -6,6 +6,12 @@ en:
         page_title: Check your answers
         heading: Check your answers
         sections:
+          application_status:
+            application_status: Status
+            status: Status
+            submitted: Date Submitted
+            assessed: Date Assessed
+            returned: Date Returned
           claim_type:
             file_ufn: Unique file number
             type_of_claim: Type of claim
@@ -105,6 +111,10 @@ en:
             defendant_disabled: Defendant disability
             
       groups:
+        application_status:
+          heading: Claim Status
+          application_status:
+            title: Status
         claim_type:
           heading: What you are claiming for
           claim_type:

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -26,4 +26,4 @@ en:
         granted: govuk-tag--green
         part_grant: govuk-tag--blue
         rejected: govuk-tag--red
-        review: govuk-tag--pink
+        review: govuk-tag--yellow

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -15,7 +15,15 @@ en:
         draft: Draft
         submitted: Submitted
         accessed: Accessed
+        granted: Granted
+        part_grant: Part Granted
+        rejected: Rejected
+        review: Further Information Requested
       status_colour:
         draft: govuk-tag--grey
         submitted: govuk-tag--primary
         accessed: govuk-tag--green
+        granted: govuk-tag--green
+        part_grant: govuk-tag--blue
+        rejected: govuk-tag--red
+        review: govuk-tag--pink

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -156,6 +156,26 @@ FactoryBot.define do
       status { :submitted }
     end
 
+    trait :granted_status do
+      status { :granted }
+    end
+
+    trait :part_granted_status do
+      status { :part_grant }
+    end
+
+    trait :review_status do
+      status { :review }
+    end
+
+    trait :rejected_status do
+      status { :rejected }
+    end
+
+    trait :updated_at do
+      updated_at { Date.new(2023, 12, 1) }
+    end
+
     trait :with_evidence do
       supporting_evidence { [build(:supporting_evidence)] }
     end

--- a/spec/presenters/check_answers/application_status_card_spec.rb
+++ b/spec/presenters/check_answers/application_status_card_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CheckAnswers::ApplicationStatusCard do
+  subject { described_class.new(claim) }
+
+  describe '#title' do
+    let(:claim) { build(:claim) }
+
+    it 'shows correct title' do
+      expect(subject.title).to eq('Status')
+    end
+  end
+
+  describe '#row data' do
+    context 'submitted' do
+      let(:claim) { build(:claim, :completed_status, :updated_at) }
+
+      it 'generates submitted rows' do
+        expect(subject.row_data).to eq(
+          [
+            {
+              head_key: 'application_status',
+              text: '<strong class="govuk-tag govuk-tag--primary">
+                  Submitted</strong>'
+            },
+            {
+              head_key: 'Date Submitted',
+              text: '01 December 2023'
+            }
+          ]
+        )
+      end
+    end
+
+    context 'granted' do
+      let(:claim) { build(:claim, :granted_status) }
+
+      it 'generates granted rows' do
+        expect(subject.row_data).to eq(
+          [
+            {
+              head_key: 'application_status',
+              text: '<strong class="govuk-tag govuk-tag--green">
+                  Granted</strong>'
+            },
+            {
+              head_key: 'Date Assessed',
+              text: nil
+            }
+          ]
+        )
+      end
+    end
+
+    context 'part granted' do
+      let(:claim) { build(:claim, :part_granted_status) }
+
+      it 'generates part granted rows' do
+        expect(subject.row_data).to eq(
+          [
+            {
+              head_key: 'application_status',
+              text: '<strong class="govuk-tag govuk-tag--blue">
+                  Part Granted</strong>'
+            },
+            {
+              head_key: 'Date Assessed',
+              text: nil
+            }
+          ]
+        )
+      end
+    end
+
+    context 'review' do
+      let(:claim) { build(:claim, :review_status) }
+
+      it 'generates review rows' do
+        expect(subject.row_data).to eq(
+          [
+            {
+              head_key: 'application_status',
+              text: '<strong class="govuk-tag govuk-tag--pink">
+                  Further Information Requested</strong>'
+            },
+            {
+              head_key: 'Date Returned',
+              text: nil
+            }
+          ]
+        )
+      end
+    end
+
+    context 'rejected' do
+      let(:claim) { build(:claim, :rejected_status) }
+
+      it 'generates rejected rows' do
+        expect(subject.row_data).to eq(
+          [
+            {
+              head_key: 'application_status',
+              text: '<strong class="govuk-tag govuk-tag--red">
+                  Rejected</strong>'
+            },
+            {
+              head_key: 'Date Returned',
+              text: nil
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/presenters/check_answers/application_status_card_spec.rb
+++ b/spec/presenters/check_answers/application_status_card_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe CheckAnswers::ApplicationStatusCard do
           [
             {
               head_key: 'application_status',
-              text: '<strong class="govuk-tag govuk-tag--primary">
-                  Submitted</strong>'
+              text: '<strong class="govuk-tag govuk-tag--primary">Submitted</strong>'
             },
             {
               head_key: 'Date Submitted',
@@ -42,8 +41,7 @@ RSpec.describe CheckAnswers::ApplicationStatusCard do
           [
             {
               head_key: 'application_status',
-              text: '<strong class="govuk-tag govuk-tag--green">
-                  Granted</strong>'
+              text: '<strong class="govuk-tag govuk-tag--green">Granted</strong>'
             },
             {
               head_key: 'Date Assessed',
@@ -62,8 +60,7 @@ RSpec.describe CheckAnswers::ApplicationStatusCard do
           [
             {
               head_key: 'application_status',
-              text: '<strong class="govuk-tag govuk-tag--blue">
-                  Part Granted</strong>'
+              text: '<strong class="govuk-tag govuk-tag--blue">Part Granted</strong>'
             },
             {
               head_key: 'Date Assessed',
@@ -82,8 +79,7 @@ RSpec.describe CheckAnswers::ApplicationStatusCard do
           [
             {
               head_key: 'application_status',
-              text: '<strong class="govuk-tag govuk-tag--pink">
-                  Further Information Requested</strong>'
+              text: '<strong class="govuk-tag govuk-tag--yellow">Further Information Requested</strong>'
             },
             {
               head_key: 'Date Returned',
@@ -102,8 +98,7 @@ RSpec.describe CheckAnswers::ApplicationStatusCard do
           [
             {
               head_key: 'application_status',
-              text: '<strong class="govuk-tag govuk-tag--red">
-                  Rejected</strong>'
+              text: '<strong class="govuk-tag govuk-tag--red">Rejected</strong>'
             },
             {
               head_key: 'Date Returned',

--- a/spec/presenters/check_answers/read_only_report_spec.rb
+++ b/spec/presenters/check_answers/read_only_report_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CheckAnswers::ReadOnlyReport do
       context 'section groups' do
         it 'returns multiple groups' do
           expect(subject.section_groups).to be_an_instance_of Array
-          expect(subject.section_groups.count).to eq 7
+          expect(subject.section_groups.count).to eq 8
         end
       end
 
@@ -33,20 +33,26 @@ RSpec.describe CheckAnswers::ReadOnlyReport do
         end
       end
 
+      context 'application status section' do
+        it 'returns single elements' do
+          expect(subject.application_status_section.count).to eq 1
+        end
+      end
+
       context 'claim type section' do
-        it 'returns multiple elements' do
+        it 'returns single elements' do
           expect(subject.claim_type_section.count).to eq 1
         end
       end
 
       context 'about you section' do
-        it 'returns multiple elements' do
+        it 'returns single elements' do
           expect(subject.about_you_section.count).to eq 1
         end
       end
 
       context 'about defendants section' do
-        it 'returns multiple elements' do
+        it 'returns single elements' do
           expect(subject.about_defendant_section.count).to eq 1
         end
       end
@@ -78,7 +84,7 @@ RSpec.describe CheckAnswers::ReadOnlyReport do
       context 'section groups' do
         it 'returns multiple groups' do
           expect(subject.section_groups).to be_an_instance_of Array
-          expect(subject.section_groups.count).to eq 7
+          expect(subject.section_groups.count).to eq 8
         end
       end
 
@@ -103,20 +109,26 @@ RSpec.describe CheckAnswers::ReadOnlyReport do
         end
       end
 
+      context 'application status section' do
+        it 'returns single elements' do
+          expect(subject.application_status_section.count).to eq 1
+        end
+      end
+
       context 'claim type section' do
-        it 'returns multiple elements' do
+        it 'returns single elements' do
           expect(subject.claim_type_section.count).to eq 1
         end
       end
 
       context 'about you section' do
-        it 'returns multiple elements' do
+        it 'returns single elements' do
           expect(subject.about_you_section.count).to eq 1
         end
       end
 
       context 'about defendants section' do
-        it 'returns multiple elements' do
+        it 'returns single elements' do
           expect(subject.about_defendant_section.count).to eq 1
         end
       end

--- a/spec/services/notify_app_store/message_builder_spec.rb
+++ b/spec/services/notify_app_store/message_builder_spec.rb
@@ -82,7 +82,10 @@ RSpec.describe NotifyAppStore::MessageBuilder do
           'number_of_witnesses' => nil,
           'office_code' => '1A123B',
           'other_info' => nil,
-          'plea' => claim.plea,
+          'plea' => {
+            value: claim.plea,
+            en: an_instance_of(String)
+          },
           'preparation_time' => nil,
           'prosecution_evidence' => nil,
           'reason_for_claim_other_details' => nil,


### PR DESCRIPTION
## Description of change

- Update status' to match list we have
- Add Status card to view only report
- Update claims page to use all status'
- Update tests

## Link to relevant ticket

[Update statuses when a claim/answer is returned](https://dsdmoj.atlassian.net/browse/CRM457-687)

## Notes for reviewer

Testing was done against a local env as we may not have the data in the pre-production environments just yet. This has been signed off by PM/DM

## Screenshots of changes (if applicable)

![Screenshot 2023-11-20 at 13 31 19](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/dc7ca4d6-2c72-4979-91b6-4868b783bb4f)
![Screenshot 2023-11-20 at 11 37 06](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/c3c6d559-bf5d-4fd2-9570-dac396f90e1d)
![Screenshot 2023-11-20 at 11 37 14](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/6f397c36-c886-43a5-b337-0d0dd98ae75f)
![Screenshot 2023-11-20 at 11 38 07](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/93c69022-95e2-4c38-ba5d-784d8c297d9c)
![Screenshot 2023-11-20 at 11 37 51](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/679793dc-90f4-4052-bd14-c0b5e42d21dd)
![Screenshot 2023-11-20 at 11 37 41](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/d59c7d81-ae16-4f04-a0c1-e4f90d813d41)
![Screenshot 2023-11-20 at 11 37 27](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/e3685356-ed8e-4efb-acb9-615200fa3622)
![Screenshot 2023-11-20 at 13 31 11](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/7954c958-e939-4546-86e0-19402215f3d4)


### Before changes:

### After changes:

## How to manually test the feature
