### PR TITLE
CRM457-546 - Dont reference memo

### DIFF
--- a/app/models/matter_type.rb
+++ b/app/models/matter_type.rb
@@ -23,7 +23,7 @@ MatterType = Struct.new(:id, :description) do
   # rubocop:enable Metrics/MethodLength
 
   def self.description_by_id(matter_id)
-    @all.find { |item| item.id == matter_id }.description
+    all.find { |item| item.id == matter_id }.description
   end
 
   def name

--- a/app/models/outcome_code.rb
+++ b/app/models/outcome_code.rb
@@ -29,7 +29,7 @@ OutcomeCode = Struct.new(:id, :description) do
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def self.description_by_id(outcome_id)
-    @all.find { |item| item.id == outcome_id }.description
+    all.find { |item| item.id == outcome_id }.description
   end
 
   def name


### PR DESCRIPTION
## Description of change

Referencing Memo can and will cause nil error. Referencing method is safer and works

## Link to relevant ticket

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
