### PR TITLE
CRM457-756 - Add Claim Submitted email

### DIFF
--- a/app/mailers/claim_submission_mailer.rb
+++ b/app/mailers/claim_submission_mailer.rb
@@ -19,7 +19,7 @@ class ClaimSubmissionMailer < GovukNotifyRails::Mailer
   private
 
   def email_recipient
-    'email@email.com'
+    Provider.find(@claim.submitter_id).email
   end
 
   def case_reference

--- a/app/mailers/claim_submission_mailer.rb
+++ b/app/mailers/claim_submission_mailer.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class ClaimSubmissionMailer < GovukNotifyRails::Mailer
+  def notify(claim)
+    @claim = claim
+    set_template('0403454c-47a5-4540-804c-cb614e77dc22')
+    set_personalisation(
+      LAA_case_reference: case_reference,
+      UFN: unique_file_number,
+      main_defendant_name: defendant_name,
+      maat_id: maat_id,
+      claim_total: claim_total,
+      date: submission_date,
+      feedback_url: feedback_url
+    )
+    mail(to: email_recipient)
+  end
+
+  private
+
+  def email_recipient
+    'email@email.com'
+  end
+
+  def case_reference
+    @claim.laa_reference
+  end
+
+  def unique_file_number
+    @claim.ufn
+  end
+
+  def main_defendant
+    @claim.defendants.find { |defendant| defendant.main == true }
+  end
+
+  def defendant_name
+    main_defendant.full_name
+  end
+
+  def maat_id
+    main_defendant.maat
+  end
+
+  def claim_total
+    items = {
+      work_items: CostSummary::WorkItems.new(@claim.work_items, @claim),
+      letters_calls: CostSummary::LettersCalls.new(@claim),
+      disbursements: CostSummary::Disbursements.new(@claim.disbursements.by_age, @claim)
+    }
+
+    NumberTo.pounds(items.values.filter_map(&:total_cost).sum)
+  end
+
+  def submission_date
+    DateTime.now.strftime('%d %B %Y')
+  end
+
+  def feedback_url
+    Rails.configuration.x.contact.feedback_url
+  end
+end

--- a/app/services/notify_app_store.rb
+++ b/app/services/notify_app_store.rb
@@ -7,6 +7,7 @@ class NotifyAppStore < ApplicationJob
     else
       begin
         notify(MessageBuilder.new(claim:, scorer:))
+        ClaimSubmissionMailer.notify(claim).deliver_later!
       rescue StandardError => e
         # we only get errors here when processing inline, which we don't want
         # to be visible to the end user, so swallow errors
@@ -17,6 +18,7 @@ class NotifyAppStore < ApplicationJob
 
   def perform(claim, scorer: RiskAssessment::RiskAssessmentScorer)
     notify(MessageBuilder.new(claim:, scorer:))
+    ClaimSubmissionMailer.notify(claim).deliver_later!
   end
 
   def notify(message_builder)

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,9 +34,11 @@ module Crm7restbackend
 
     config.x.contact.case_enquiries_tel = '0300 200 2020'
     config.x.contact.support_email = 'CRM457@digital.justice.gov.uk'
+    config.x.contact.feedback_url = 'tbc'
     config.x.analytics.cookies_consent_name = 'cookies_preferences_set'
     config.x.analytics.cookies_consent_expiration = 1.year
     config.x.analytics.analytics_consent_name = 'analytics_preferences_set'
     config.x.analytics.analytics_consent_expiration = 1.year
+
   end
 end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     submitter { Provider.find_by(uid: 'test-user') || create(:provider) }
     office_code { '1A123B' }
+    laa_reference { 'LAA-n4AohV' }
 
     trait :complete do
       firm_details

--- a/spec/mailers/claim_submission_mailer_spec.rb
+++ b/spec/mailers/claim_submission_mailer_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClaimSubmissionMailer, type: :mailer do
+  let(:feedback_template) { '0403454c-47a5-4540-804c-cb614e77dc22' }
+  let(:claim) { build(:claim, :case_type_magistrates, :main_defendant, :letters_calls) }
+
+  describe '#notify' do
+    subject(:mail) { described_class.notify(claim) }
+
+    it 'is a govuk_notify delivery' do
+      expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+    end
+
+    it 'sets the recipient from config' do
+      expect(mail.to).to eq(['provider@example.com'])
+    end
+
+    it 'sets the template' do
+      expect(
+        mail.govuk_notify_template
+      ).to eq feedback_template
+    end
+
+    context 'with personalisation' do
+      it 'sets personalisation from args' do
+        expect(
+          mail.govuk_notify_personalisation
+        ).to include(
+          LAA_case_reference: 'LAA-n4AohV',
+          UFN: '123456/001',
+          main_defendant_name: 'bobjim',
+          maat_id: 'AA1',
+          claim_total: '£20.45',
+          date: DateTime.now.strftime('%d %B %Y'),
+          feedback_url: 'tbc'
+        )
+      end
+    end
+  end
+end

--- a/spec/services/notify_app_store/message_builder_spec.rb
+++ b/spec/services/notify_app_store/message_builder_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe NotifyAppStore::MessageBuilder do
           'id' => claim.id,
           'in_area' => 'yes',
           'is_other_info' => nil,
-          'laa_reference' => nil,
+          'laa_reference' => 'LAA-n4AohV',
           'letters_and_calls' => [
             { 'count' => 2, 'pricing' => 4.09, 'type' => { en: 'Letters', value: 'letters' }, 'uplift' => nil },
             { 'count' => 3, 'pricing' => 4.09, 'type' => { en: 'Calls', value: 'calls' }, 'uplift' => nil }

--- a/spec/services/notify_app_store_spec.rb
+++ b/spec/services/notify_app_store_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe NotifyAppStore do
   before do
     allow(described_class::MessageBuilder).to receive(:new)
       .and_return(message_builder)
+    allow(ClaimSubmissionMailer).to receive_message_chain(:notify, :deliver_later!)
   end
 
   describe '#process' do


### PR DESCRIPTION
## Description of change

- Add mailer for claim submissions
- Call mailer after sending claim to app store
- Add and update tests

## Link to relevant ticket

[CRM457-756](https://dsdmoj.atlassian.net/browse/CRM457-756)

## Notes for reviewer

- Email is sent to the provider email stored from the portal login. We are not using live data at the moment so you may need support viewing the notify dashboard

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
