### PR TITLE
CRM457-784 - Add Vat message to work items and letters/calls

### DIFF
--- a/app/controllers/steps/letters_calls_controller.rb
+++ b/app/controllers/steps/letters_calls_controller.rb
@@ -4,6 +4,7 @@ module Steps
       @form_object = LettersCallsForm.build(
         current_application
       )
+      @vat_included = current_application.firm_office.vat_registered == YesNoAnswer::YES.to_s
     end
 
     def update

--- a/app/controllers/steps/work_item_controller.rb
+++ b/app/controllers/steps/work_item_controller.rb
@@ -7,6 +7,7 @@ module Steps
         work_item,
         application: current_application,
       )
+      @vat_included = current_application.firm_office.vat_registered == YesNoAnswer::YES.to_s
     end
 
     def update

--- a/app/views/steps/letters_calls/edit.html.erb
+++ b/app/views/steps/letters_calls/edit.html.erb
@@ -4,6 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
+    <% if @vat_included %>
+      <p><%= t('.vat_info') %></p>
+    <% end %>
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>

--- a/app/views/steps/work_item/edit.html.erb
+++ b/app/views/steps/work_item/edit.html.erb
@@ -4,6 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
+    <% if @vat_included %>
+      <p><%= t('.vat_info') %></p>
+    <% end %>
     <%= govuk_error_summary(@form_object) %>
     <%= step_form @form_object do |f| %>
       <%= f.govuk_radio_buttons_fieldset :work_type, legend: { size: 's' } do %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -76,7 +76,7 @@ en:
               blank: "Enter a postcode"
               invalid: "Enter a valid UK postcode"
             vat_registered:
-              blank: "Select if VAT registered"
+              blank: "Select yat if you firm is VAT registered"
           attributes: *firm_office_form
         steps/firm_details/solicitor_form:
           summary: &solicitor_form

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -82,6 +82,7 @@ en:
       edit:
         page_title: Letters and phone calls
         heading: Letters and phone calls
+        vat_info: VAT is not included in any of these items. We'll show you totals including VAT before you submit your claim.
         total_cost: Total cost
         summary: View by letters and phone calls
         items: Items
@@ -98,6 +99,7 @@ en:
       edit:
         page_title: What work item are you claiming for?
         heading: What work item are you claiming for?
+        vat_info: VAT is not included in any of these items. We'll show you totals including VAT before you submit your claim.
         work_type_pricing: "%{price} per hour"
         calculation: Calculation
         before_uplift: Before uplift

--- a/spec/steps/claim_details/integration_spec.rb
+++ b/spec/steps/claim_details/integration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'User can fill in claim details', type: :system do
-  let(:claim) { create(:claim) }
+  let(:claim) { create(:claim, :firm_details) }
 
   before do
     visit provider_saml_omniauth_callback_path

--- a/spec/steps/letters_calls/integration_spec.rb
+++ b/spec/steps/letters_calls/integration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'User can fill in claim type details', type: :system do
-  let(:claim) { create(:claim) }
+  let(:claim) { create(:claim, :firm_details) }
 
   before do
     visit provider_saml_omniauth_callback_path

--- a/spec/steps/work_items/add/controller_spec.rb
+++ b/spec/steps/work_items/add/controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Steps::WorkItemController, type: :controller do
                   ->(scope) { { work_item_id: scope.work_item&.id || '4321' } }
 
   describe '#edit' do
-    let(:application) { create(:claim, work_items:) }
+    let(:application) { create(:claim, :firm_details, work_items:) }
     let(:work_items) { [] }
 
     context 'when work_item_id is not passed in' do

--- a/spec/steps/work_items/integration_spec.rb
+++ b/spec/steps/work_items/integration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'User can manage work items', type: :system do
-  let(:claim) { create(:claim, claim_type: ClaimType::NON_STANDARD_MAGISTRATE) }
+  let(:claim) { create(:claim, :firm_details, claim_type: ClaimType::NON_STANDARD_MAGISTRATE) }
 
   before do
     visit provider_saml_omniauth_callback_path

--- a/spec/support/steps/a_generic_step_controller.rb
+++ b/spec/support/steps/a_generic_step_controller.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
     # to the shared examples, or to also create the partner associated record.
     #
     context 'when application is found' do
-      let(:existing_case) { create(:claim, submitter: auth_provider) }
+      let(:existing_case) { create(:claim, :firm_details, submitter: auth_provider) }
 
       it 'responds with HTTP success' do
         get :edit, params: { id: existing_case, **additional_params }


### PR DESCRIPTION
## Description of change

- Updates error message for adding VAT registered
- Adds VAT message to Work items page
- Adds VAT message to Letters and Calls page
- Updates tests

## Link to relevant ticket

[CRM457-784](https://dsdmoj.atlassian.net/browse/CRM457-784)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-784]: https://dsdmoj.atlassian.net/browse/CRM457-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ