### PR TITLE
CRM457-783 - Add VAT flag to check answers cards

### DIFF
--- a/app/presenters/check_answers/your_details_card.rb
+++ b/app/presenters/check_answers/your_details_card.rb
@@ -26,6 +26,10 @@ module CheckAnswers
           text: format_address(firm_details_form.firm_office)
         },
         {
+          head_key: 'vat_registered',
+          text: check_missing(firm_details_form.firm_office.vat_registered.to_s.capitalize)
+        },
+        {
           head_key: 'solicitor_full_name',
           text: check_missing(firm_details_form.solicitor.full_name)
         },

--- a/config/locales/en/check_answers.yml
+++ b/config/locales/en/check_answers.yml
@@ -25,6 +25,7 @@ en:
             firm_name: Firm name
             firm_account_number: Firm account number
             firm_address: Firm address
+            vat_registered: Firm VAT registered
             solicitor_full_name: Solicitor full name
             solicitor_reference_number: Solicitor reference number
             contact_full_name: Contact full name

--- a/spec/presenters/check_answers/your_details_card_spec.rb
+++ b/spec/presenters/check_answers/your_details_card_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe CheckAnswers::YourDetailsCard do
               text: '2 Laywer Suite<br>Unit B<br>Lawyer Town<br>CR0 1RE'
             },
             {
+              head_key: 'vat_registered',
+              text: 'Yes'
+            },
+            {
               head_key: 'solicitor_full_name',
               text: 'Richard Jenkins'
             },
@@ -75,6 +79,10 @@ RSpec.describe CheckAnswers::YourDetailsCard do
               text: '2 Laywer Suite<br>Lawyer Town<br>CR0 1RE'
             },
             {
+              head_key: 'vat_registered',
+              text: 'Yes'
+            },
+            {
               head_key: 'solicitor_full_name',
               text: 'Richard Jenkins'
             },
@@ -103,6 +111,10 @@ RSpec.describe CheckAnswers::YourDetailsCard do
             },
             {
               head_key: 'firm_address',
+              text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
+            },
+            {
+              head_key: 'vat_registered',
               text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
             },
             {
@@ -138,6 +150,10 @@ RSpec.describe CheckAnswers::YourDetailsCard do
               text: '2 Laywer Suite<br><strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
             },
             {
+              head_key: 'vat_registered',
+              text: 'Yes'
+            },
+            {
               head_key: 'solicitor_full_name',
               text: 'Richard Jenkins'
             },
@@ -168,6 +184,10 @@ RSpec.describe CheckAnswers::YourDetailsCard do
             {
               head_key: 'firm_address',
               text: '2 Laywer Suite<br><strong class="govuk-tag govuk-tag--red">Incomplete</strong><br>CR0 1RE'
+            },
+            {
+              head_key: 'vat_registered',
+              text: 'Yes'
             },
             {
               head_key: 'solicitor_full_name',


### PR DESCRIPTION
## Description of change

- Add VAT registered flag to check answers card

## Link to relevant ticket

[CRM457-783](https://dsdmoj.atlassian.net/browse/CRM457-783)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
