### PR TITLE
CRM457-783 - Add VAT values to Cost Summary

### DIFF
--- a/app/controllers/steps/cost_summary_controller.rb
+++ b/app/controllers/steps/cost_summary_controller.rb
@@ -2,6 +2,7 @@ module Steps
   class CostSummaryController < Steps::BaseStepController
     def show
       @report = CostSummary::Report.new(current_application)
+      @vat_registered = current_application.firm_office.vat_registered == YesNoAnswer::YES.to_s
     end
   end
 end

--- a/app/forms/steps/disbursement_cost_form.rb
+++ b/app/forms/steps/disbursement_cost_form.rb
@@ -46,23 +46,19 @@ module Steps
     end
 
     def total_cost_pre_vat
-      return @total_cost_pre_vat if defined?(@total_cost_pre_vat)
-
-      @total_cost_pre_vat = if other_disbursement_type?
-                              total_cost_without_vat
-                            elsif miles
-                              miles.to_f * multiplier
-                            end
+      @total_cost_pre_vat ||= if other_disbursement_type?
+                                total_cost_without_vat
+                              elsif miles
+                                miles.to_f * multiplier
+                              end
     end
 
     def total_cost
-      return @total_cost if defined?(@total_cost)
-
-      @total_cost = if apply_vat && total_cost_pre_vat
-                      total_cost_pre_vat + vat
-                    else
-                      total_cost_pre_vat
-                    end
+      @total_cost ||= if apply_vat && total_cost_pre_vat
+                        total_cost_pre_vat + vat
+                      else
+                        total_cost_pre_vat
+                      end
     end
 
     private

--- a/app/forms/steps/letters_calls_form.rb
+++ b/app/forms/steps/letters_calls_form.rb
@@ -66,6 +66,16 @@ module Steps
       letters_after_uplift.to_f + calls_after_uplift.to_f
     end
 
+    def total_cost_inc_vat
+      calculate_vat
+    end
+
+    def calculate_vat
+      return 0 unless total_cost
+
+      (total_cost * pricing.vat) + total_cost
+    end
+
     private
 
     def letters_row

--- a/app/forms/steps/letters_calls_form.rb
+++ b/app/forms/steps/letters_calls_form.rb
@@ -1,6 +1,7 @@
 require 'steps/base_form_object'
 
 module Steps
+  # rubocop:disable Metrics/ClassLength
   class LettersCallsForm < Steps::BaseFormObject
     attr_writer :apply_calls_uplift, :apply_letters_uplift
 
@@ -131,4 +132,5 @@ module Steps
       calls.to_f * pricing.letters if calls && !calls.zero?
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/presenters/check_answers/disbursement_costs_card.rb
+++ b/app/presenters/check_answers/disbursement_costs_card.rb
@@ -41,12 +41,20 @@ module CheckAnswers
           head_key: 'total',
           text: disbursement_total,
           footer: true
-        }
+        },
+        {
+          head_key: 'total_inc_vat',
+          text: disbursement_total_inc_vat
+        },
       ]
     end
 
-    def disbursement_total
+    def disbursement_total_inc_vat
       NumberTo.pounds(disbursements.total_cost)
+    end
+
+    def disbursement_total
+      NumberTo.pounds(disbursements.disbursement_forms.filter_map(&:total_cost_pre_vat).sum)
     end
   end
 end

--- a/app/presenters/check_answers/letters_calls_card.rb
+++ b/app/presenters/check_answers/letters_calls_card.rb
@@ -98,20 +98,12 @@ module CheckAnswers
     end
 
     def total_cost_inc_vat
-      format_total(calculate_vat)
-    end
-
-    def calculate_vat
-      (letters_calls_form.total_cost * vat_rate) + letters_calls_form.total_cost
+      format_total(letters_calls_form.total_cost_inc_vat)
     end
 
     def format_total(value)
       text = "<strong>#{currency_value(value)}</strong>"
       ApplicationController.helpers.sanitize(text, tags: %w[strong])
-    end
-
-    def vat_rate
-      Pricing.for(@claim).vat
     end
 
     def letters

--- a/app/presenters/check_answers/work_items_card.rb
+++ b/app/presenters/check_answers/work_items_card.rb
@@ -7,7 +7,6 @@ module CheckAnswers
     def initialize(claim)
       @claim = claim
       @work_items = CostSummary::WorkItems.new(claim.work_items, claim)
-      @vat_rate = vat_rate(claim)
       @group = 'about_claim'
       @section = 'work_items'
     end
@@ -75,7 +74,7 @@ module CheckAnswers
     end
 
     def work_item_total_inc_vat
-      format_total(item_plus_vat(work_items))
+      format_total(work_items.total_cost_inc_vat)
     end
 
     def format_total(value)
@@ -85,14 +84,6 @@ module CheckAnswers
 
     def currency_value(value)
       NumberTo.pounds(value || 0)
-    end
-
-    def item_plus_vat(item)
-      (item.total_cost * @vat_rate) + item.total_cost
-    end
-
-    def vat_rate(claim)
-      Pricing.for(claim).vat
     end
   end
 end

--- a/app/presenters/cost_summary/base.rb
+++ b/app/presenters/cost_summary/base.rb
@@ -10,5 +10,9 @@ module CostSummary
         I18n.t("summary.#{self.class::TRANSLATION_KEY.to_s.underscore}.#{key}", **)
       end
     end
+
+    def vat_rate
+      Pricing.for(@claim).vat
+    end
   end
 end

--- a/app/presenters/cost_summary/disbursements.rb
+++ b/app/presenters/cost_summary/disbursements.rb
@@ -14,17 +14,21 @@ module CostSummary
       disbursement_forms.map do |form|
         {
           key: { text: translated_text(form), classes: 'govuk-summary-list__value-width-50' },
-          value: { text: NumberTo.pounds(form.total_cost) },
+          value: { text: NumberTo.pounds(form.total_cost_pre_vat) },
         }
       end
     end
 
     def total_cost
-      @total_cost ||= disbursement_forms.filter_map(&:total_cost).sum
+      @total_cost ||= disbursement_forms.filter_map(&:total_cost_pre_vat).sum
+    end
+
+    def total_cost_inc_vat
+      @total_cost_inc_vat ||= disbursement_forms.filter_map(&:total_cost).sum
     end
 
     def title
-      translate('disbursements', total: NumberTo.pounds(total_cost))
+      translate('disbursements', total: NumberTo.pounds(total_cost_inc_vat))
     end
 
     private

--- a/app/presenters/cost_summary/letters_calls.rb
+++ b/app/presenters/cost_summary/letters_calls.rb
@@ -4,6 +4,7 @@ module CostSummary
     attr_reader :letters_calls_form
 
     def initialize(claim)
+      @claim = claim
       @letters_calls_form = Steps::LettersCallsForm.build(claim)
     end
 
@@ -24,8 +25,12 @@ module CostSummary
       letters_calls_form.total_cost || 0
     end
 
+    def total_cost_inc_vat
+      letters_calls_form.total_cost_inc_vat || 0
+    end
+
     def title
-      translate('letters_calls', total: NumberTo.pounds(total_cost || 0))
+      translate('letters_calls', total: NumberTo.pounds(total_cost_inc_vat || 0))
     end
   end
 end

--- a/app/presenters/cost_summary/report.rb
+++ b/app/presenters/cost_summary/report.rb
@@ -30,6 +30,10 @@ module CostSummary
       NumberTo.pounds(items.values.filter_map(&:total_cost).sum)
     end
 
+    def total_cost_inc_vat
+      NumberTo.pounds(items.values.filter_map(&:total_cost_inc_vat).sum)
+    end
+
     private
 
     def actions(key)

--- a/app/presenters/cost_summary/report.rb
+++ b/app/presenters/cost_summary/report.rb
@@ -30,10 +30,6 @@ module CostSummary
       NumberTo.pounds(items.values.filter_map(&:total_cost).sum)
     end
 
-    def total_cost_inc_vat
-      NumberTo.pounds(items.values.filter_map(&:total_cost_inc_vat).sum)
-    end
-
     private
 
     def actions(key)

--- a/app/presenters/cost_summary/report.rb
+++ b/app/presenters/cost_summary/report.rb
@@ -21,13 +21,17 @@ module CostSummary
             title: data.title,
             actions: actions(name)
           },
-          rows: [header_row, *data.rows, footer_row(data)],
+          rows: [header_row, *data.rows, *footer_row(data)],
         }
       end
     end
 
     def total_cost
       NumberTo.pounds(items.values.filter_map(&:total_cost).sum)
+    end
+
+    def total_cost_inc_vat
+      NumberTo.pounds(items.values.filter_map(&:total_cost_inc_vat).sum)
     end
 
     private
@@ -50,11 +54,24 @@ module CostSummary
     end
 
     def footer_row(data)
-      {
-        key: { text: translate('.footer.total'), classes: 'govuk-summary-list__value-width-50' },
-        value: { text: NumberTo.pounds(data.total_cost), classes: 'govuk-summary-list__value-bold' },
-        classes: 'govuk-summary-list__row-double-border'
-      }
+      [
+        {
+          key: { text: translate('.footer.total'), classes: 'govuk-summary-list__value-width-50' },
+          value: { text: NumberTo.pounds(data.total_cost), classes: 'govuk-summary-list__value-bold' },
+          classes: 'govuk-summary-list__row-double-border'
+        }
+      ] + footer_vat_row(data)
+    end
+
+    def footer_vat_row(data)
+      return [] if data.total_cost_inc_vat.zero?
+
+      [
+        {
+          key: { text: translate('.footer.total_inc_vat'), classes: 'govuk-summary-list__value-width-50' },
+          value: { text: NumberTo.pounds(data.total_cost_inc_vat), classes: 'govuk-summary-list__value-bold' },
+        }
+      ]
     end
   end
 end

--- a/app/presenters/cost_summary/work_items.rb
+++ b/app/presenters/cost_summary/work_items.rb
@@ -26,8 +26,16 @@ module CostSummary
       @total_cost ||= work_item_forms.sum(&:total_cost)
     end
 
+    def total_cost_inc_vat
+      @total_cost_inc_vat ||= calculate_vat
+    end
+
+    def calculate_vat
+      (total_cost * vat_rate) + total_cost
+    end
+
     def title
-      translate('work_items', total: NumberTo.pounds(total_cost))
+      translate('work_items', total: NumberTo.pounds(total_cost_inc_vat))
     end
   end
 end

--- a/app/views/steps/cost_summary/show.html.erb
+++ b/app/views/steps/cost_summary/show.html.erb
@@ -5,7 +5,19 @@
   <div class="govuk-grid-column-one-thirds">
     <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
     <h2 class="govuk-hint govuk-!-font-size-24"><%= t('.estimate') %></h2>
-    <div class="govuk-heading-l"><%= @report.total_cost %></div>
+    <div class="govuk-heading-l"><%= @vat_registered ? @report.total_cost_inc_vat : @report.total_cost %></div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= govuk_details(summary_text: t('.payment_claim')) do %>
+          <%=
+            head = [t('.total'), t('.total_inc_vat')]
+            rows = [[@report.total_cost, @report.total_cost_inc_vat]]
+            govuk_table(head:, rows:)
+          %>
+        <% end %>
+      </div>
+    </div>
 
     <% @report.sections.each do |section| %>
       <%= govuk_summary_list(**section) %>

--- a/config/locales/en/check_answers.yml
+++ b/config/locales/en/check_answers.yml
@@ -83,6 +83,8 @@ en:
           disbursements:
             items: Items
             items_total: <strong>Total per item</strong>
+            total: Total
+            total_inc_vat: Total (including VAT)
           work_items:
             items: Items
             items_total: <strong>Total per item</strong>

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -178,6 +178,9 @@ en:
     cost_summary:
       show:
         page_title: Check your payment claim
+        payment_claim: Payment Claim
+        total: Cost
+        total_inc_vat: Cost (including VAT)
         heading: Check your payment claim
         estimate: 'Total estimated:'
     other_info:

--- a/config/locales/en/summary.yml
+++ b/config/locales/en/summary.yml
@@ -7,6 +7,7 @@ en:
       total: Total per item
     footer:
       total: Total
+      total_inc_vat: Total (including VAT)
     cost_summary/work_items:
       work_items: Work items total %{total}
       preparation: Preparation

--- a/spec/presenters/check_answers/disbursement_cost_card_spec.rb
+++ b/spec/presenters/check_answers/disbursement_cost_card_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe CheckAnswers::DisbursementCostsCard do
             head_key: 'total',
             text: '£90.00',
             footer: true
+          },
+          {
+            head_key: 'total_inc_vat',
+            text: '£90.00'
           }
         ]
       )

--- a/spec/presenters/cost_summary/disbursements_spec.rb
+++ b/spec/presenters/cost_summary/disbursements_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe CostSummary::Disbursements do
       instance_double(Disbursement, disbursement_type: 'car', other_type: nil)
     ]
   end
-  let(:form_car) { instance_double(Steps::DisbursementCostForm, record: disbursements[0], total_cost: 100.0) }
-  let(:form_dna) { instance_double(Steps::DisbursementCostForm, record: disbursements[1], total_cost: 70.0) }
-  let(:form_custom) { instance_double(Steps::DisbursementCostForm, record: disbursements[2], total_cost: 40.0) }
-  let(:form_car2) { instance_double(Steps::DisbursementCostForm, record: disbursements[3], total_cost: 90.0) }
+  let(:form_car) { instance_double(Steps::DisbursementCostForm, record: disbursements[0], total_cost: 100.0, total_cost_pre_vat: 90.0) }
+  let(:form_dna) { instance_double(Steps::DisbursementCostForm, record: disbursements[1], total_cost: 70.0, total_cost_pre_vat: 60.0) }
+  let(:form_custom) { instance_double(Steps::DisbursementCostForm, record: disbursements[2], total_cost: 40.0, total_cost_pre_vat: 30.0) }
+  let(:form_car2) { instance_double(Steps::DisbursementCostForm, record: disbursements[3], total_cost: 90.0, total_cost_pre_vat: 80.0) }
 
   before do
     allow(Steps::DisbursementCostForm).to receive(:build).with(disbursements[0],

--- a/spec/presenters/cost_summary/disbursements_spec.rb
+++ b/spec/presenters/cost_summary/disbursements_spec.rb
@@ -47,19 +47,19 @@ RSpec.describe CostSummary::Disbursements do
         [
           {
             key: { classes: 'govuk-summary-list__value-width-50', text: 'Car' },
-            value: { text: '£100.00' }
+            value: { text: '£90.00' }
           },
           {
             key: { classes: 'govuk-summary-list__value-width-50', text: 'DNA Testing' },
-            value: { text: '£70.00' }
+            value: { text: '£60.00' }
           },
           {
             key: { classes: 'govuk-summary-list__value-width-50', text: 'Custom' },
-            value: { text: '£40.00' }
+            value: { text: '£30.00' }
           },
           {
             key: { classes: 'govuk-summary-list__value-width-50', text: 'Car' },
-            value: { text: '£90.00' }
+            value: { text: '£80.00' }
           }
         ]
       )
@@ -69,7 +69,7 @@ RSpec.describe CostSummary::Disbursements do
 
   describe '#total_cost' do
     it 'delegates to the form' do
-      expect(subject.total_cost).to eq(300.00)
+      expect(subject.total_cost).to eq(260.00)
     end
   end
 

--- a/spec/presenters/cost_summary/disbursements_spec.rb
+++ b/spec/presenters/cost_summary/disbursements_spec.rb
@@ -14,10 +14,18 @@ RSpec.describe CostSummary::Disbursements do
       instance_double(Disbursement, disbursement_type: 'car', other_type: nil)
     ]
   end
-  let(:form_car) { instance_double(Steps::DisbursementCostForm, record: disbursements[0], total_cost: 100.0, total_cost_pre_vat: 90.0) }
-  let(:form_dna) { instance_double(Steps::DisbursementCostForm, record: disbursements[1], total_cost: 70.0, total_cost_pre_vat: 60.0) }
-  let(:form_custom) { instance_double(Steps::DisbursementCostForm, record: disbursements[2], total_cost: 40.0, total_cost_pre_vat: 30.0) }
-  let(:form_car2) { instance_double(Steps::DisbursementCostForm, record: disbursements[3], total_cost: 90.0, total_cost_pre_vat: 80.0) }
+  let(:form_car) do
+    instance_double(Steps::DisbursementCostForm, record: disbursements[0], total_cost: 100.0, total_cost_pre_vat: 90.0)
+  end
+  let(:form_dna) do
+    instance_double(Steps::DisbursementCostForm, record: disbursements[1], total_cost: 70.0, total_cost_pre_vat: 60.0)
+  end
+  let(:form_custom) do
+    instance_double(Steps::DisbursementCostForm, record: disbursements[2], total_cost: 40.0, total_cost_pre_vat: 30.0)
+  end
+  let(:form_car2) do
+    instance_double(Steps::DisbursementCostForm, record: disbursements[3], total_cost: 90.0, total_cost_pre_vat: 80.0)
+  end
 
   before do
     allow(Steps::DisbursementCostForm).to receive(:build).with(disbursements[0],

--- a/spec/presenters/cost_summary/letters_and_calls_spec.rb
+++ b/spec/presenters/cost_summary/letters_and_calls_spec.rb
@@ -4,10 +4,11 @@ RSpec.describe CostSummary::LettersCalls do
   subject { described_class.new(claim) }
 
   let(:claim) { instance_double(Claim) }
-  let(:form) { instance_double(Steps::LettersCallsForm, letters_after_uplift:, calls_after_uplift:, total_cost:) }
+  let(:form) { instance_double(Steps::LettersCallsForm, letters_after_uplift:, calls_after_uplift:, total_cost:, total_cost_inc_vat:) }
   let(:letters_after_uplift) { 25.0 }
   let(:calls_after_uplift) { 75.0 }
   let(:total_cost) { 100.00 }
+  let(:total_cost_inc_vat) { 120.00 }
 
   before do
     allow(Steps::LettersCallsForm).to receive(:build).and_return(form)
@@ -45,7 +46,7 @@ RSpec.describe CostSummary::LettersCalls do
 
   describe '#title' do
     it 'translates with total cost' do
-      expect(subject.title).to eq('Letters and phone calls total £100.00')
+      expect(subject.title).to eq('Letters and phone calls total £120.00')
     end
   end
 end

--- a/spec/presenters/cost_summary/letters_and_calls_spec.rb
+++ b/spec/presenters/cost_summary/letters_and_calls_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe CostSummary::LettersCalls do
   subject { described_class.new(claim) }
 
   let(:claim) { instance_double(Claim) }
-  let(:form) { instance_double(Steps::LettersCallsForm, letters_after_uplift:, calls_after_uplift:, total_cost:, total_cost_inc_vat:) }
+  let(:form) do
+    instance_double(Steps::LettersCallsForm, letters_after_uplift:, calls_after_uplift:, total_cost:,
+   total_cost_inc_vat:)
+  end
   let(:letters_after_uplift) { 25.0 }
   let(:calls_after_uplift) { 75.0 }
   let(:total_cost) { 100.00 }

--- a/spec/presenters/cost_summary/report_spec.rb
+++ b/spec/presenters/cost_summary/report_spec.rb
@@ -9,13 +9,16 @@ RSpec.describe CostSummary::Report do
   let(:disbursements_scope) { double(:scope, by_age: [instance_double(Disbursement)]) }
   let(:id) { SecureRandom.uuid }
   let(:letters_calls) do
-    instance_double(CostSummary::LettersCalls, title: l_title, rows: l_rows, total_cost: l_total_cost, total_cost_inc_vat: l_total_cost_inc_vat)
+    instance_double(CostSummary::LettersCalls, title: l_title, rows: l_rows, total_cost: l_total_cost,
+total_cost_inc_vat: l_total_cost_inc_vat)
   end
   let(:work_items) do
-    instance_double(CostSummary::WorkItems, title: wi_title, rows: wi_rows, total_cost: wi_total_cost, total_cost_inc_vat: wi_total_cost_inc_vat)
+    instance_double(CostSummary::WorkItems, title: wi_title, rows: wi_rows, total_cost: wi_total_cost,
+total_cost_inc_vat: wi_total_cost_inc_vat)
   end
   let(:disbursements) do
-    instance_double(CostSummary::Disbursements, title: d_title, rows: d_rows, total_cost: d_total_cost, total_cost_inc_vat: d_total_cost_inc_vat)
+    instance_double(CostSummary::Disbursements, title: d_title, rows: d_rows, total_cost: d_total_cost,
+total_cost_inc_vat: d_total_cost_inc_vat)
   end
   let(:l_title) { 'Letters and Calls Total £100.00' }
   let(:l_rows) { [double(:row_data)] }

--- a/spec/presenters/cost_summary/report_spec.rb
+++ b/spec/presenters/cost_summary/report_spec.rb
@@ -9,23 +9,26 @@ RSpec.describe CostSummary::Report do
   let(:disbursements_scope) { double(:scope, by_age: [instance_double(Disbursement)]) }
   let(:id) { SecureRandom.uuid }
   let(:letters_calls) do
-    instance_double(CostSummary::LettersCalls, title: l_title, rows: l_rows, total_cost: l_total_cost)
+    instance_double(CostSummary::LettersCalls, title: l_title, rows: l_rows, total_cost: l_total_cost, total_cost_inc_vat: l_total_cost_inc_vat)
   end
   let(:work_items) do
-    instance_double(CostSummary::WorkItems, title: wi_title, rows: wi_rows, total_cost: wi_total_cost)
+    instance_double(CostSummary::WorkItems, title: wi_title, rows: wi_rows, total_cost: wi_total_cost, total_cost_inc_vat: wi_total_cost_inc_vat)
   end
   let(:disbursements) do
-    instance_double(CostSummary::Disbursements, title: d_title, rows: d_rows, total_cost: d_total_cost)
+    instance_double(CostSummary::Disbursements, title: d_title, rows: d_rows, total_cost: d_total_cost, total_cost_inc_vat: d_total_cost_inc_vat)
   end
   let(:l_title) { 'Letters and Calls Total £100.00' }
   let(:l_rows) { [double(:row_data)] }
   let(:l_total_cost) { 100.00 }
+  let(:l_total_cost_inc_vat) { 120.00 }
   let(:wi_title) { 'Work Items Total £75.00' }
   let(:wi_rows) { [double(:row_data)] }
   let(:wi_total_cost) { 75.00 }
+  let(:wi_total_cost_inc_vat) { 85.00 }
   let(:d_title) { 'Disbursements Total £55.00' }
   let(:d_rows) { [double(:row_data)] }
   let(:d_total_cost) { 55.00 }
+  let(:d_total_cost_inc_vat) { 65.00 }
 
   before do
     allow(CostSummary::WorkItems).to receive(:new).and_return(work_items)
@@ -62,6 +65,10 @@ RSpec.describe CostSummary::Report do
                 classes: 'govuk-summary-list__row-double-border',
                 key: { classes: 'govuk-summary-list__value-width-50', text: 'Total' },
                 value: { classes: 'govuk-summary-list__value-bold', text: '£75.00' }
+              },
+              {
+                key: { classes: 'govuk-summary-list__value-width-50', text: 'Total (including VAT)' },
+                value: { classes: 'govuk-summary-list__value-bold', text: '£85.00' }
               }
             ]
           },
@@ -80,6 +87,10 @@ RSpec.describe CostSummary::Report do
                 classes: 'govuk-summary-list__row-double-border',
                 key: { classes: 'govuk-summary-list__value-width-50', text: 'Total' },
                 value: { classes: 'govuk-summary-list__value-bold', text: '£100.00' }
+              },
+              {
+                key: { classes: 'govuk-summary-list__value-width-50', text: 'Total (including VAT)' },
+                value: { classes: 'govuk-summary-list__value-bold', text: '£120.00' }
               }
             ]
           },
@@ -98,6 +109,10 @@ RSpec.describe CostSummary::Report do
                 classes: 'govuk-summary-list__row-double-border',
                 key: { classes: 'govuk-summary-list__value-width-50', text: 'Total' },
                 value: { classes: 'govuk-summary-list__value-bold', text: '£55.00' }
+              },
+              {
+                key: { classes: 'govuk-summary-list__value-width-50', text: 'Total (including VAT)' },
+                value: { classes: 'govuk-summary-list__value-bold', text: '£65.00' }
               }
             ]
           }

--- a/spec/presenters/cost_summary/work_items_spec.rb
+++ b/spec/presenters/cost_summary/work_items_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe CostSummary::WorkItems do
   subject { described_class.new(work_items, claim) }
 
-  let(:claim) { instance_double(Claim, assigned_counsel:, in_area:) }
+  let(:claim) { instance_double(Claim, assigned_counsel:, in_area:, date:) }
   let(:assigned_counsel) { 'no' }
   let(:in_area) { 'yes' }
+  let(:date) { Date.new(2008, 11, 22) }
   let(:work_items) { [instance_double(WorkItem), instance_double(WorkItem), instance_double(WorkItem)] }
   let(:form_advocacy) { instance_double(Steps::WorkItemForm, work_type: WorkTypes::ADVOCACY, total_cost: 100.0) }
   let(:form_advocacy2) { instance_double(Steps::WorkItemForm, work_type: WorkTypes::ADVOCACY, total_cost: 70.0) }
@@ -77,7 +78,7 @@ RSpec.describe CostSummary::WorkItems do
 
   describe '#title' do
     it 'translates with total cost' do
-      expect(subject.title).to eq('Work items total £210.00')
+      expect(subject.title).to eq('Work items total £252.00')
     end
   end
 end

--- a/spec/steps/cost_summary/controller_spec.rb
+++ b/spec/steps/cost_summary/controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::CostSummaryController, type: :controller do
   it_behaves_like 'a show step controller'
 
   describe '#show' do
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:claim, :firm_details) }
 
     before { claim.update(navigation_stack:) }
 

--- a/spec/steps/cost_summary/integration_spec.rb
+++ b/spec/steps/cost_summary/integration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'User can see cost breakdowns', type: :system do
-  let(:claim) { create(:claim, :letters_calls, work_items:, disbursements:) }
+  let(:claim) { create(:claim, :firm_details, :letters_calls, work_items:, disbursements:) }
   let(:work_items) do
     [
       build(:work_item, :attendance_without_counsel, time_spent: 90),

--- a/spec/steps/cost_summary/integration_spec.rb
+++ b/spec/steps/cost_summary/integration_spec.rb
@@ -30,26 +30,29 @@ RSpec.describe 'User can see cost breakdowns', type: :system do
 
     expect(values).to eq(
       [
-        'Work items total £285.39',
+        'Work items total £342.47',
         'Items', 'Total per item',
         'Attendance without counsel', '£78.23', # 52.15 * 90 / 60
         'Preparation', '£0.00',
         'Advocacy', '£207.16', # 65.42 * (104 + 86) / 60
         'Total', '£285.39',
+        'Total (including VAT)', '£342.47',
 
-        'Letters and phone calls total £20.45',
+        'Letters and phone calls total £24.54',
         'Items', 'Total per item',
         'Letters', '£8.18', # 4.09 * 2
         'Phone calls', '£12.27', # 4.09 * 3
         'Total', '£20.45',
+        'Total (including VAT)', '£24.54',
 
         'Disbursements total £259.00',
         'Items', 'Total per item',
-        'Car', '£108.00',
+        'Car', '£90.00',
         'DNA Testing', '£30.00',
         'Custom', '£40.00',
-        'Car', '£81.00',
-        'Total', '£259.00'
+        'Car', '£67.50',
+        'Total', '£227.50',
+        'Total (including VAT)', '£259.00'
       ]
     )
   end

--- a/spec/steps/disbursements/integration_spec.rb
+++ b/spec/steps/disbursements/integration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'User can manage disbursements', type: :system do
-  let(:claim) { create(:claim) }
+  let(:claim) { create(:claim, :firm_details) }
 
   before do
     visit provider_saml_omniauth_callback_path


### PR DESCRIPTION
## Description of change

- Refactor to put vat code in common location
- Add VAT rows to cost summary
- Update tests

## Link to relevant ticket

[CRM457-783](https://dsdmoj.atlassian.net/browse/CRM457-783)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-783]: https://dsdmoj.atlassian.net/browse/CRM457-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ