### PR TITLE
CRM457-866: bump rails defaults 7.0 to 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'tzinfo-data'
 gem 'hmcts_common_platform', github: 'ministryofjustice/hmcts_common_platform', tag: 'v0.2.0'
 
 group :development, :test do
-  gem 'debug', '~> 1.9.1'
+  gem 'debug', platforms: %i[mri windows]
   gem 'dotenv-rails'
   gem 'erb_lint', require: false
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,7 +509,7 @@ DEPENDENCIES
   clamby (~> 1.6)
   cuprite (~> 0.15)
   dartsass-rails (~> 0.5.0)
-  debug (~> 1.9.1)
+  debug
   dotenv-rails
   erb_lint
   factory_bot_rails (>= 6.4.3)

--- a/app/forms/steps/answer_equality_form.rb
+++ b/app/forms/steps/answer_equality_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 # this is a form to determine where to move to the equality questions
 # or skip them, as such it does not persist anything to DB
 module Steps

--- a/app/forms/steps/case_details_form.rb
+++ b/app/forms/steps/case_details_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class CaseDetailsForm < Steps::BaseFormObject
     BOOLEAN_FIELDS = %i[assigned_counsel unassigned_counsel agent_instructed remitted_to_magistrate].freeze

--- a/app/forms/steps/case_disposal_form.rb
+++ b/app/forms/steps/case_disposal_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class CaseDisposalForm < Steps::BaseFormObject
     attribute :plea, :value_object, source: PleaOptions

--- a/app/forms/steps/claim_details_form.rb
+++ b/app/forms/steps/claim_details_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class ClaimDetailsForm < Steps::BaseFormObject
     BOOLEAN_FIELDS = %i[supplemental_claim preparation_time work_before work_after].freeze

--- a/app/forms/steps/claim_type_form.rb
+++ b/app/forms/steps/claim_type_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class ClaimTypeForm < Steps::BaseFormObject
     attribute :ufn, :string

--- a/app/forms/steps/defendant_delete_form.rb
+++ b/app/forms/steps/defendant_delete_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class DefendantDeleteForm < Steps::BaseFormObject
     attribute :id

--- a/app/forms/steps/defendant_details_form.rb
+++ b/app/forms/steps/defendant_details_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class DefendantDetailsForm < Steps::BaseFormObject
     attribute :full_name, :string

--- a/app/forms/steps/disbursement_add_form.rb
+++ b/app/forms/steps/disbursement_add_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class DisbursementAddForm < Steps::BaseFormObject
     attribute :has_disbursements, :value_object, source: YesNoAnswer

--- a/app/forms/steps/disbursement_cost_form.rb
+++ b/app/forms/steps/disbursement_cost_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class DisbursementCostForm < Steps::BaseFormObject
     attr_writer :apply_vat

--- a/app/forms/steps/disbursement_type_form.rb
+++ b/app/forms/steps/disbursement_type_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class DisbursementTypeForm < Steps::BaseFormObject
     attribute :disbursement_date, :multiparam_date

--- a/app/forms/steps/equality_questions_form.rb
+++ b/app/forms/steps/equality_questions_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 # this is a form to determine where to move to the equality questions
 # or skip them, as such it does not persist anything to DB
 module Steps

--- a/app/forms/steps/firm_details/firm_office_form.rb
+++ b/app/forms/steps/firm_details/firm_office_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   module FirmDetails
     class FirmOfficeForm < Steps::BaseFormObject

--- a/app/forms/steps/firm_details/solicitor_form.rb
+++ b/app/forms/steps/firm_details/solicitor_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   module FirmDetails
     class SolicitorForm < Steps::BaseFormObject

--- a/app/forms/steps/firm_details_form.rb
+++ b/app/forms/steps/firm_details_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class FirmDetailsForm < Steps::BaseFormObject
     attr_accessor :firm_office_attributes, :solicitor_attributes

--- a/app/forms/steps/hearing_details_form.rb
+++ b/app/forms/steps/hearing_details_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class HearingDetailsForm < Steps::BaseFormObject
     attribute :first_hearing_date, :multiparam_date

--- a/app/forms/steps/letters_calls_form.rb
+++ b/app/forms/steps/letters_calls_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   # rubocop:disable Metrics/ClassLength
   class LettersCallsForm < Steps::BaseFormObject

--- a/app/forms/steps/other_info_form.rb
+++ b/app/forms/steps/other_info_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class OtherInfoForm < Steps::BaseFormObject
     BOOLEAN_FIELDS = %i[is_other_info concluded].freeze

--- a/app/forms/steps/reason_for_claim_form.rb
+++ b/app/forms/steps/reason_for_claim_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class ReasonForClaimForm < Steps::BaseFormObject
     attribute :reasons_for_claim, array: true, default: []

--- a/app/forms/steps/solicitor_declaration_form.rb
+++ b/app/forms/steps/solicitor_declaration_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class SolicitorDeclarationForm < Steps::BaseFormObject
     attribute :signatory_name, :string

--- a/app/forms/steps/supporting_evidence_form.rb
+++ b/app/forms/steps/supporting_evidence_form.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'steps/base_form_object'
-
 module Steps
   class SupportingEvidenceForm < Steps::BaseFormObject
     attribute :send_by_post, :boolean

--- a/app/forms/steps/work_item_form.rb
+++ b/app/forms/steps/work_item_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class WorkItemForm < Steps::BaseFormObject
     attr_writer :apply_uplift

--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,7 @@ require "fileutils"
 APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
+  system(*args, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,11 @@ module Crm7restbackend
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    # Please, add to the `ignore` list any other `lib` subdirectories that do
+    # not contain `.rb` files, or that should not be reloaded or eager loaded.
+    # Common ones are `templates`, `generators`, or `middleware`, for example.
+    config.autoload_lib(ignore: %w(assets tasks))
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ Bundler.require(*Rails.groups)
 module Crm7restbackend
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,12 +17,12 @@ Rails.application.configure do
   # Enable server timing
   config.server_timing = true
 
-  # Highlight code that enqueued background job in logs.
-  config.active_job.verbose_enqueue_logs = true
-
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?
+    config.action_controller.perform_caching = true
+    config.action_controller.enable_fragment_cache_logging = true
+
     config.cache_store = :memory_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
@@ -60,6 +60,12 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   config.hosts = ['crm7dev.apps.live.cloud-platform.service.justice.gov.uk', 'localhost', '127.0.0.1', '.ngrok-free.app']
+
+  # Highlight code that enqueued background job in logs.
+  config.active_job.verbose_enqueue_logs = true
+
+  # Suppress logger output for asset requests.
+  config.assets.quiet = true
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.enable_reloading = true
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -16,6 +16,9 @@ Rails.application.configure do
 
   # Enable server timing
   config.server_timing = true
+
+  # Highlight code that enqueued background job in logs.
+  config.active_job.verbose_enqueue_logs = true
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
@@ -66,6 +69,9 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
 
   config.logstasher.enabled = true
   config.logstasher.logger_path = 'log/logstasher_development.log'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
@@ -13,14 +13,13 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
 
-  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
+  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
+  # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
@@ -41,18 +40,25 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::Logger.new($stdout)
+                      .tap  { |logger| logger.formatter = Logger::Formatter.new }
+                      .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  end
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
+
+  # Info include generic and useful information about system operation, but avoids logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
+  # want to log everything, set the level to "debug".
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "crm7restbackend_production"
 
   config.action_mailer.perform_caching = false
@@ -71,21 +77,16 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Enable DNS rebinding protection and other `Host` header attacks.
+  # config.hosts = [
+  #   "example.com",     # Allow requests from example.com
+  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
+  # ]
+  # Skip DNS rebinding protection for the default health check endpoint.
+  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   config.logstasher.enabled = true
   config.logstasher.logger_path = 'log/logstasher.log'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,6 +14,7 @@ Rails.application.configure do
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
+  config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
   # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
@@ -21,6 +22,12 @@ Rails.application.configure do
 
   # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+
+  # Compress CSS using a preprocessor.
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
@@ -36,6 +43,10 @@ Rails.application.configure do
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
+  # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
@@ -62,9 +73,6 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "crm7restbackend_production"
 
   config.action_mailer.perform_caching = false
-
-  config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: ENV.fetch('DOMAIN_URL', nil) }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,10 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # NOTE: this should be set to false. Relying on the fallback implies some assets are
+  # not being compiled until the first request to the server. The Dockerfiles'
+  # `rails assets:precompile` command should compile all assets.
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,12 +8,13 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = true
+  # While tests run files are not watched, reloading is not necessary.
+  config.enable_reloading = false
 
-  # Eager loading loads your whole application. When running a single test locally,
-  # this probably isn't necessary. It's a good idea to do in a continuous integration
-  # system, or in some way before deploying your code.
+  # Eager loading loads your entire application. When running a single test locally,
+  # this is usually not necessary, and can slow down your test suite. However, it's
+  # recommended that you enable it in continuous integration systems to ensure eager
+  # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
@@ -23,12 +24,12 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
@@ -60,6 +61,9 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
 
   config.logstasher.enabled = true
   config.logstasher.logger_path = 'log/logstasher_test.log'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # Raise exceptions instead of rendering exception templates.
+  # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
@@ -38,9 +38,6 @@ Rails.application.configure do
   config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
-
-  # Set default mailer host to allow url helpers to generate urls in mailers.
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -16,4 +16,3 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules/govuk-fro
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,9 +16,9 @@
 #     # policy.report_uri "/csp-violation-report-endpoint"
 #   end
 #
-#   # Generate session nonces for permitted importmap and inline scripts
+#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
+#   config.content_security_policy_nonce_directives = %w(script-src style-src)
 #
 #   # Report violations without enforcing the policy.
 #   # config.content_security_policy_report_only = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,8 +2,8 @@
 
 Devise.setup do |config|
   require 'devise/orm/active_record'
-  require 'laa_portal/saml_strategy'
-  require 'laa_portal/saml_setup'
+  require Rails.root.join('app/lib/laa_portal/saml_strategy')
+  require Rails.root.join('app/lib/laa_portal/saml_setup')
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,8 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-# Configure parameters to be filtered from the log file. Use this to limit dissemination of
-# sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
-# notations and behaviors.
+# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
+# Use this to limit dissemination of sensitive information.
+# See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
 ]

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 require 'omniauth'
-require 'laa_portal/saml_strategy'
+require Rails.root.join('app/lib/laa_portal/saml_strategy')
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   configure do |config|

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,11 +1,11 @@
 # Define an application-wide HTTP permissions policy. For further
-# information see https://developers.google.com/web/updates/2018/06/feature-policy
-#
-# Rails.application.config.permissions_policy do |f|
-#   f.camera      :none
-#   f.gyroscope   :none
-#   f.microphone  :none
-#   f.usb         :none
-#   f.fullscreen  :self
-#   f.payment     :self, "https://secure.example.com"
+# information see: https://developers.google.com/web/updates/2018/06/feature-policy
+
+# Rails.application.config.permissions_policy do |policy|
+#   policy.camera      :none
+#   policy.gyroscope   :none
+#   policy.microphone  :none
+#   policy.usb         :none
+#   policy.fullscreen  :self
+#   policy.payment     :self, "https://secure.example.com"
 # end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,20 +24,5 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-# preload_app!
-
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/gems/laa_multi_step_forms/app/forms/steps/add_another_form.rb
+++ b/gems/laa_multi_step_forms/app/forms/steps/add_another_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 # this is a form to determine where to move next section to repeat
 # an existing section, as such it does not persist anything to DB
 module Steps

--- a/gems/laa_multi_step_forms/app/forms/steps/delete_form.rb
+++ b/gems/laa_multi_step_forms/app/forms/steps/delete_form.rb
@@ -1,5 +1,3 @@
-require 'steps/base_form_object'
-
 module Steps
   class DeleteForm < Steps::BaseFormObject
     attribute :id

--- a/gems/laa_multi_step_forms/spec/dummy/config/environments/test.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/zeitwerk_spec.rb
+++ b/spec/zeitwerk_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'Zeitwerk compliance' do
+  it 'eager loads all files without errors' do
+    expect { Rails.application.eager_load! }.not_to raise_error
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## Description of change
Bump to use rails 7.1 defaults.

Keep upto date and so we can safely move to further rails bumps, such as 7.2

## Link to relevant ticket

[CRM457-866](https://dsdmoj.atlassian.net/browse/CRM457-866)

## Notes for reviewer
Will need UATing manually

[CRM457-866]: https://dsdmoj.atlassian.net/browse/CRM457-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ