### PR TITLE
CRM457-774: Workaround for Puma/k8s dropped request problem

### DIFF
--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 30"] # Workaround for occasional lost requests - see https://github.com/puma/puma/blob/master/docs/kubernetes.md#running-puma-in-kubernetes
           env:
             - name: REDIS_HOST
               valueFrom:


### PR DESCRIPTION
## Description of change
CRM457-774: Workaround for Puma/k8s dropped request problem

Possible cause of bug [CRM457-774](https://dsdmoj.atlassian.net/browse/CRM457-774) in assess app
but a good practice to avoid dropping requests anyway.

See: https://github.com/puma/puma/blob/master/docs/kubernetes.md#running-puma-in-kubernetes

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-774)

## Notes for reviewer
As long as config is parseable and we can deploy there is not much more we can test


[CRM457-774]: https://dsdmoj.atlassian.net/browse/CRM457-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ