### PR TITLE
SPIKE: Simple prior authority first screens implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -190,3 +190,7 @@ Rails/RedundantActiveRecordAllMethod:
 # Causing false positives when implemented in methods
 Rails/ActionControllerFlashBeforeRender:
   Enabled: false
+
+# Our ApplicationController inherits from MultiStepForms, but PriorAuthority controllers shouldn't
+Rails/ApplicationController:
+  Enabled: false

--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -1,0 +1,26 @@
+module PriorAuthority
+  class ApplicationsController < PriorAuthority::BaseController
+    def index
+      @model = current_provider.prior_authority_applications.draft
+    end
+
+    def show
+      @model = current_provider.prior_authority_applications.find(params[:id])
+    end
+
+    def create
+      application = current_provider.prior_authority_applications.create!
+      redirect_to prior_authority_application_prison_law_form_path(application)
+    end
+
+    def confirm_delete
+      @model = current_provider.prior_authority_applications.find(params[:id])
+    end
+
+    def destroy
+      @model = current_provider.prior_authority_applications.find(params[:id])
+      @model.destroy
+      redirect_to prior_authority_applications_path
+    end
+  end
+end

--- a/app/controllers/prior_authority/authority_value_forms_controller.rb
+++ b/app/controllers/prior_authority/authority_value_forms_controller.rb
@@ -1,0 +1,29 @@
+module PriorAuthority
+  class AuthorityValueFormsController < PriorAuthority::BaseController
+    before_action :instantiate_model
+    def update
+      @model.assign_attributes(allowed_params)
+      if @model.valid?
+        if @model.less_than_five_hundred
+          redirect_to offboard_prior_authority_application_path(@model)
+        else
+          redirect_to prior_authority_application_ufn_form_path(@model)
+        end
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def instantiate_model
+      @model = current_provider.prior_authority_applications
+                               .find(params[:application_id])
+                               .becomes(PriorAuthority::AuthorityValueForm)
+    end
+
+    def allowed_params
+      params.require(:prior_authority_authority_value_form).permit(:less_than_five_hundred)
+    end
+  end
+end

--- a/app/controllers/prior_authority/base_controller.rb
+++ b/app/controllers/prior_authority/base_controller.rb
@@ -1,0 +1,8 @@
+module PriorAuthority
+  class BaseController < ActionController::Base
+    include CookieConcern
+    before_action :set_default_cookies
+    before_action :authenticate_provider!
+    layout 'prior_authority'
+  end
+end

--- a/app/controllers/prior_authority/case_contact_forms_controller.rb
+++ b/app/controllers/prior_authority/case_contact_forms_controller.rb
@@ -1,0 +1,26 @@
+module PriorAuthority
+  class CaseContactFormsController < PriorAuthority::BaseController
+    before_action :instantiate_model
+
+    def update
+      if @model.extended_update(allowed_params, skip_validation: params[:commit_draft])
+        redirect_to prior_authority_application_path(@model)
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def instantiate_model
+      @model = current_provider.prior_authority_applications
+                               .find(params[:application_id])
+                               .becomes(PriorAuthority::CaseContactForm)
+    end
+
+    def allowed_params
+      params.require(:prior_authority_case_contact_form)
+            .permit(:contact_name, :contact_email, :firm_name, :firm_account_number)
+    end
+  end
+end

--- a/app/controllers/prior_authority/prison_law_forms_controller.rb
+++ b/app/controllers/prior_authority/prison_law_forms_controller.rb
@@ -1,0 +1,24 @@
+module PriorAuthority
+  class PrisonLawFormsController < PriorAuthority::BaseController
+    before_action :instantiate_model
+    def update
+      if @model.update(allowed_params)
+        redirect_to prior_authority_application_authority_value_form_path(@model)
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def instantiate_model
+      @model = current_provider.prior_authority_applications
+                               .find(params[:application_id])
+                               .becomes(PriorAuthority::PrisonLawForm)
+    end
+
+    def allowed_params
+      params.require(:prior_authority_prison_law_form).permit(:prison_law)
+    end
+  end
+end

--- a/app/controllers/prior_authority/ufn_forms_controller.rb
+++ b/app/controllers/prior_authority/ufn_forms_controller.rb
@@ -1,0 +1,24 @@
+module PriorAuthority
+  class UfnFormsController < PriorAuthority::BaseController
+    before_action :instantiate_model
+    def update
+      if @model.extended_update(allowed_params)
+        redirect_to prior_authority_application_path(@model)
+      else
+        render :show
+      end
+    end
+
+    private
+
+    def instantiate_model
+      @model = current_provider.prior_authority_applications
+                               .find(params[:application_id])
+                               .becomes(PriorAuthority::UfnForm)
+    end
+
+    def allowed_params
+      params.require(:prior_authority_ufn_form).permit(:ufn)
+    end
+  end
+end

--- a/app/helpers/prior_authority_helper.rb
+++ b/app/helpers/prior_authority_helper.rb
@@ -1,0 +1,10 @@
+module PriorAuthorityHelper
+  YES_NO_OPTIONS = [
+    [true, I18n.t('prior_authority.generic.yes_choice')],
+    [false, I18n.t('prior_authority.generic.no_choice')],
+  ].freeze
+
+  def yes_no_options
+    YES_NO_OPTIONS
+  end
+end

--- a/app/models/prior_authority/authority_value_form.rb
+++ b/app/models/prior_authority/authority_value_form.rb
@@ -1,0 +1,6 @@
+module PriorAuthority
+  class AuthorityValueForm < PriorAuthorityApplication
+    attribute :less_than_five_hundred, :boolean
+    validates :less_than_five_hundred, inclusion: { in: [true, false] }
+  end
+end

--- a/app/models/prior_authority/case_contact_form.rb
+++ b/app/models/prior_authority/case_contact_form.rb
@@ -1,0 +1,23 @@
+module PriorAuthority
+  class CaseContactForm < PriorAuthorityApplication
+    validates :contact_name, presence: true
+    validates :contact_email, presence: true
+    validates :firm_name, presence: true
+    validates :firm_account_number, presence: true
+
+    def extended_update(attributes, skip_validation: false)
+      if skip_validation
+        assign_attributes(attributes)
+        update(case_contact_form_status: :incomplete)
+        save(validate: false)
+        return true
+      end
+
+      return false unless update(attributes)
+
+      update(case_contact_form_status: :complete)
+
+      true
+    end
+  end
+end

--- a/app/models/prior_authority/prison_law_form.rb
+++ b/app/models/prior_authority/prison_law_form.rb
@@ -1,0 +1,5 @@
+module PriorAuthority
+  class PrisonLawForm < PriorAuthorityApplication
+    validates :prison_law, inclusion: { in: [true, false] }
+  end
+end

--- a/app/models/prior_authority/ufn_form.rb
+++ b/app/models/prior_authority/ufn_form.rb
@@ -1,0 +1,28 @@
+module PriorAuthority
+  class UfnForm < PriorAuthorityApplication
+    validates :ufn, presence: true
+
+    def extended_update(attributes)
+      return false unless update(attributes)
+      return true unless pre_draft?
+
+      PriorAuthorityApplication.transaction do
+        update(status: PriorAuthorityApplication.statuses[:draft],
+               ufn_form_status: :complete,
+               laa_reference: generate_laa_reference)
+      end
+      true
+    end
+
+    private
+
+    def generate_laa_reference
+      proposed_reference = nil
+      loop do
+        proposed_reference = "LAA-#{SecureRandom.base58(6)}"
+        break unless PriorAuthorityApplication.find_by(laa_reference: proposed_reference)
+      end
+      proposed_reference
+    end
+  end
+end

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -1,0 +1,15 @@
+class PriorAuthorityApplication < ApplicationRecord
+  belongs_to :provider
+
+  attribute :prison_law, :boolean
+  attribute :ufn, :string
+  attribute :contact_name, :string
+  attribute :contact_email, :string
+  attribute :firm_name, :string
+  attribute :firm_account_number, :string
+  attribute :ufn_form_status, :string
+  attribute :case_contact_form_status, :string
+  enum :status, { pre_draft: 'pre_draft', draft: 'draft', submitted: 'submitted' }
+  attribute :created_at, :datetime
+  attribute :updated_at, :datetime
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -16,6 +16,8 @@ class Provider < ApplicationRecord
     office_codes.size > 1
   end
 
+  has_many :prior_authority_applications, dependent: :destroy
+
   class << self
     def from_omniauth(auth)
       find_or_initialize_by(auth_provider: auth.provider, uid: auth.uid).tap do |record|

--- a/app/views/layouts/prior_authority.html.erb
+++ b/app/views/layouts/prior_authority.html.erb
@@ -1,0 +1,39 @@
+<% content_for?(:page_title) ? yield(:page_title) : fallback_title %>
+
+<% content_for(:head) do %>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+<% end %>
+
+<% content_for(:analytics) do %>
+  <%= render partial: 'layouts/analytics' %>
+<% end %>
+
+<% content_for(:cookie_banner) do %>
+  <% render partial: 'layouts/cookie_banner/main', locals: { cookies_preferences_set: @cookie_preferences_set } %>
+<% end %>
+
+<% content_for(:service_name) do %>
+  <%= link_to t('prior_authority.service_name'), provider_signed_in? ? prior_authority_applications_path : root_path,
+              class: 'govuk-header__link govuk-header__service-name', id: 'header-service-name' %>
+<% end %>
+
+<% content_for(:header_navigation) do %>
+  <% render partial: 'layouts/header_navigation' %>
+<% end %>
+
+<% content_for(:phase_banner) do %>
+  <% render partial: 'layouts/phase_banner' %>
+<% end %>
+
+<% content_for(:content) do %>
+  <%= yield %>
+<% end %>
+
+<% content_for(:footer_links) do %>
+  <% render partial: 'layouts/footer_links' %>
+<% end %>
+
+<%# render partial: 'layouts/developer_tools' if FeatureFlags.developer_tools.enabled? %>
+
+<%= render template: 'layouts/govuk_template', layout: false %>

--- a/app/views/prior_authority/applications/confirm_delete.html.erb
+++ b/app/views/prior_authority/applications/confirm_delete.html.erb
@@ -1,0 +1,15 @@
+<% title t('.page_title') %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
+    <p class="govuk-text">
+      <strong><%= t('.laa_reference') %></strong> <%= @model.laa_reference %>
+      <br>
+      <strong><%= t('.ufn_reference') %></strong> <%= @model.ufn %>
+    </p>
+    <div class="govuk-button-group">
+      <%= govuk_button_to(t('.yes_delete'), prior_authority_application_path(@model), warning: true, method: :delete) %>
+      <%= govuk_button_to(t('.no_delete'), prior_authority_root_path, method: :get) %>
+    </div>
+  </div>
+</div>

--- a/app/views/prior_authority/applications/index.html.erb
+++ b/app/views/prior_authority/applications/index.html.erb
@@ -1,0 +1,59 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6"><%= t('.page_title') %></h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= button_to prior_authority_applications_path, class: "govuk-button govuk-button--start govuk-!-margin-bottom-6" do %>
+      <%= t('.start_application') %>
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    <% end %>
+  </div>
+
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <%= govuk_tabs(title: t(".page_title")) do |c|
+      c.with_tab(label: t(".tabs.drafts")) do %>
+        <table class="govuk-table" data-module="moj-sortable-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.ufn') %></th>
+            <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.laa_reference') %></th>
+            <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.last_updated') %></th>
+            <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.action') %></th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body app-task-list__items">
+          <% @model.each do |application| %>
+            <tr class="govuk-table__row app-task-list__item">
+              <td class="govuk-table__cell">
+                <%= link_to prior_authority_application_path(application) do %>
+                  <%= application.ufn %>
+                <% end %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= application.laa_reference %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= application.updated_at.strftime('%d %B %Y') %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= link_to t(".delete"), confirm_delete_prior_authority_application_path(application) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end; end %>
+  </div>
+</div>

--- a/app/views/prior_authority/applications/index.html.erb
+++ b/app/views/prior_authority/applications/index.html.erb
@@ -23,7 +23,7 @@
 
     <%= govuk_tabs(title: t(".page_title")) do |c|
       c.with_tab(label: t(".tabs.drafts")) do %>
-        <table class="govuk-table" data-module="moj-sortable-table">
+        <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="tab_drafts">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.ufn') %></th>

--- a/app/views/prior_authority/applications/offboard.html.erb
+++ b/app/views/prior_authority/applications/offboard.html.erb
@@ -1,0 +1,8 @@
+<% title t('.page_title') %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
+    <p class="govuk-text"><%= t('.explanation') %></p>
+    <%= link_to t('.finish'), prior_authority_root_path, class: 'govuk-button' %>
+  </div>
+</div>

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -1,0 +1,71 @@
+<% title t('.page_title') %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
+
+    <p class="govuk-text"><%= t('.introduction') %></p>
+
+    <h2 class="govuk-heading-m"></h2>
+
+    <ol class="moj-task-list">
+      <li>
+        <h2 class="moj-task-list__section"><%= t('.headings.application_details') %></h2>
+        <ul class="moj-task-list__items">
+          <li class="moj-task-list__item">
+            <span class="app-task-list__task-name">
+              <%= link_to t('.sections.ufn'), prior_authority_application_ufn_form_path(@model) %>
+            </span>
+            <strong id="claim_type.non_standard_magistrate-status" class="govuk-tag app-task-list__tag <%= t(".status_colour.#{@model.ufn_form_status}") %>">
+            <%= t("statuses.#{@model.ufn_form_status}") %></strong>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <h2 class="moj-task-list__section"><%= t('.headings.case_contact') %></h2>
+        <ul class="moj-task-list__items">
+          <li class="moj-task-list__item">
+            <span class="app-task-list__task-name">
+              <%= link_to t('.sections.case_contact'), prior_authority_application_case_contact_form_path(@model) %>
+            </span>
+            <strong id="claim_type.non_standard_magistrate-status" class="govuk-tag app-task-list__tag <%= t(".status_colour.#{@model.case_contact_form_status}") %>"><%= t("statuses.#{@model.case_contact_form_status}") %></strong>
+          </li>
+        </ul>
+      </li>
+    </ol>
+
+    <%= link_button t('.back_to_applications'), prior_authority_applications_path, class: 'govuk-button--secondary' %>
+  </div>
+
+  <div class="govuk-grid-column-one-third app-grid-column--sticky">
+    <aside class="app-aside__bar--blue aside-task-list" role="complementary">
+      <h3 class="govuk-heading-s govuk-!-margin-0">
+        <%= t('.application_reference') %>
+      </h3>
+      <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-0">
+        <strong>
+          <%= t('.unique_file_number') %>
+        </strong>
+      </p>
+      <p class="govuk-body">
+        <%= @model.ufn %>
+      </p>
+      <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-0">
+        <strong>
+          <%= t('.laa_reference') %>
+        </strong>
+      </p>
+      <p class="govuk-body">
+        <%= @model.laa_reference %>
+      </p>
+      <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-0">
+        <strong>
+          <%= t('.under_prison_law') %>
+        </strong>
+      </p>
+      <p class="govuk-body">
+        <%= t(@model.prison_law ? 'prior_authority.generic.yes_choice' : 'prior_authority.generic.no_choice') %>
+      </p>
+    </aside>
+  </div>
+</div>
+

--- a/app/views/prior_authority/authority_value_forms/show.html.erb
+++ b/app/views/prior_authority/authority_value_forms/show.html.erb
@@ -1,0 +1,12 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@model) %>
+    <%= form_with(model: @model, url: prior_authority_application_authority_value_form_path(@model)) do |form| %>
+      <%= form.govuk_collection_radio_buttons :less_than_five_hundred, yes_no_options, :first, :last,
+                                          legend: { text: t(".page_title"), size: "xl", tag: "h1" } %>
+      <%= form.govuk_submit t("prior_authority.generic.save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/prior_authority/case_contact_forms/show.html.erb
+++ b/app/views/prior_authority/case_contact_forms/show.html.erb
@@ -1,0 +1,21 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@model) %>
+    <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
+    <%= form_with(model: @model, url: prior_authority_application_case_contact_form_path(@model)) do |form| %>
+      <%= form.govuk_text_field :contact_name, label: { text: t(".contact_name"), size: 'm' } %>
+      <%= form.govuk_text_field :contact_email, label: { text: t(".contact_email"), size: 'm' } %>
+      <%= form.govuk_text_field :firm_name, label: { text: t(".firm_name"), size: 'm' } %>
+      <%= form.govuk_text_field :firm_account_number, label: { text: t(".firm_account_number"), size: 'm' }, hint: { text: t(".hint") }  %>
+      <%= form.govuk_submit t("prior_authority.generic.save_and_continue") %>
+      <button type="submit"
+              formnovalidate="formnovalidate"
+              class="govuk-button govuk-button--secondary"
+              data-module="govuk-button"
+              data-prevent-double-click="true"
+              name="commit_draft"><%= t("prior_authority.generic.save_and_come_back_later") %></button>
+    <% end %>
+  </div>
+</div>

--- a/app/views/prior_authority/prison_law_forms/show.html.erb
+++ b/app/views/prior_authority/prison_law_forms/show.html.erb
@@ -1,0 +1,12 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@model) %>
+    <%= form_with(model: @model, url: prior_authority_application_prison_law_form_path(@model)) do |form| %>
+      <%= form.govuk_collection_radio_buttons :prison_law, yes_no_options, :first, :last,
+                                          legend: { text: t(".page_title"), size: "xl", tag: "h1" } %>
+      <%= form.govuk_submit t("prior_authority.generic.save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/prior_authority/ufn_forms/show.html.erb
+++ b/app/views/prior_authority/ufn_forms/show.html.erb
@@ -1,0 +1,13 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@model) %>
+    <%= form_with(model: @model, url: prior_authority_application_ufn_form_path(@model)) do |form| %>
+      <%= form.govuk_text_field :ufn,
+                          label: { text: t(".page_title"), size: "xl", tag: "h1" },
+                          hint: { text: t(".hint") } %>
+      <%= form.govuk_submit t("prior_authority.generic.save_and_continue") %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/prior_authority.yml
+++ b/config/locales/en/prior_authority.yml
@@ -1,0 +1,99 @@
+en:
+  prior_authority:
+    service_name: 'Apply for prior authority to incur disbursements'
+    generic:
+      yes_choice: 'Yes'
+      no_choice: 'No'
+      save_and_continue: 'Save and continue'
+      save_and_come_back_later: 'Save and come back later'
+    applications:
+      index:
+        page_title: Your prior authority applications
+        start_application: Start an application
+        tabs:
+          drafts: Drafts
+        header:
+          ufn: UFN
+          laa_reference: LAA reference
+          last_updated: Last updated
+          action: Action
+        status_colour:
+          draft: govuk-tag--grey
+        status:
+          draft: Draft
+        delete: Delete
+      confirm_delete:
+        page_title: Are you sure you want to delete this draft application?
+        laa_reference: "LAA reference:"
+        ufn_reference: "UFN reference:"
+        yes_delete: "Yes, delete it"
+        no_delete: "No, do not delete it"
+      offboard:
+        page_title: You do not need to apply
+        explanation: You do not need to apply for prior authority to incur disbursements for a Prison Law matter if the total authority is less than £500.
+        finish: 'Finish'
+      show:
+        page_title: 'Your application progress'
+        introduction: 'If you leave this page before submitting, you can return later to complete the application.'
+        headings:
+          application_details: 'Application details'
+          case_contact: '1. Case contact'
+        sections:
+          ufn: 'Unique file number'
+          case_contact: 'Case contact'
+        statuses:
+          complete: 'Complete'
+          not_started: 'Not started'
+          incomplete: 'Incomplete'
+        status_colour:
+          not_started: govuk-tag--grey
+          incomplete: govuk-tag--grey
+          complete: ""
+        back_to_applications: 'Back to applications'
+        unique_file_number: Unique file number
+        laa_reference: "LAA reference"
+        under_prison_law: "Under Prison Law"
+    prison_law_forms:
+      show:
+        page_title: Is this a Prison Law matter?
+    authority_value_forms:
+      show:
+        page_title: Are you applying for a total authority of less than £500?
+    ufn_forms:
+      show:
+        page_title: What is your unique file number?
+        hint: For example 310223/001
+    case_contact_forms:
+      show:
+        page_title: Case contact
+        contact_name: Full name
+        contact_email: Email address
+        firm_name: Firm name
+        firm_account_number: Firm account number
+        hint: For example, 1A234B
+
+  activerecord:
+    errors:
+      models:
+        prior_authority/prison_law_form:
+          attributes:
+            prison_law:
+              inclusion: Select if this is a Prison Law matter
+        prior_authority/authority_value_form:
+          attributes:
+            less_than_five_hundred:
+              inclusion: Select if you are applying for a total authority of less than £500
+        prior_authority/ufn_form:
+          attributes:
+            ufn:
+              blank: Enter your unique file number for this claim
+        prior_authority/case_contact_form:
+          attributes:
+            contact_name:
+              blank: Enter the full contact name
+            contact_email:
+              blank: Enter the contact email address
+            firm_name:
+              blank: Enter the firm name
+            firm_account_number:
+              blank: Enter the firm account number

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,21 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :prior_authority, path: 'prior-authority' do
+    resources :applications, only: %i[index create show destroy] do
+      resource :prison_law_form, path: 'prison-law', only: %i[show update]
+      resource :authority_value_form, path: 'authority-value', only: %i[show update]
+      resource :ufn_form, path: 'ufn', only: %i[show update]
+      resource :case_contact_form, path: 'case-contact', only: %i[show update]
+      member do
+        get 'offboard'
+        get :confirm_delete, path: 'confirm-delete'
+      end
+    end
+
+    root to: 'applications#index'
+  end
+
   match '*path', to: 'laa_multi_step_forms/errors#not_found', via: :all, constraints:
     lambda { |_request| Rails.application.config.consider_all_requests_local }
 end

--- a/db/migrate/20240111093801_create_prior_authority_applications.rb
+++ b/db/migrate/20240111093801_create_prior_authority_applications.rb
@@ -1,0 +1,18 @@
+class CreatePriorAuthorityApplications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :prior_authority_applications, id: :uuid do |t|
+      t.boolean :prison_law
+      t.string :ufn
+      t.string :contact_name
+      t.string :contact_email
+      t.string :firm_name
+      t.string :firm_account_number
+      t.string :laa_reference
+      t.string :ufn_form_status, default: 'not_started'
+      t.string :case_contact_form_status, default: 'not_started'
+      t.string :status, default: 'pre_draft'
+      t.references :provider, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_20_134618) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_11_093801) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -160,6 +160,23 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_20_134618) do
     t.datetime "updated_at", null: false
     t.string "vat_registered"
     t.index ["previous_id"], name: "index_firm_offices_on_previous_id"
+  end
+
+  create_table "prior_authority_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "prison_law"
+    t.string "ufn"
+    t.string "contact_name"
+    t.string "contact_email"
+    t.string "firm_name"
+    t.string "firm_account_number"
+    t.string "laa_reference"
+    t.string "ufn_form_status", default: "not_started"
+    t.string "case_contact_form_status", default: "not_started"
+    t.string "status", default: "pre_draft"
+    t.uuid "provider_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider_id"], name: "index_prior_authority_applications_on_provider_id"
   end
 
   create_table "providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/gems/laa_multi_step_forms/Gemfile.lock
+++ b/gems/laa_multi_step_forms/Gemfile.lock
@@ -315,6 +315,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
 

--- a/spec/models/prior_authority/ufn_form_spec.rb
+++ b/spec/models/prior_authority/ufn_form_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe PriorAuthority::UfnForm do
+  describe '#extended_update' do
+    it 'will not regenerate an existing laa reference if the record is already a draft' do
+      provider = create(:provider)
+      record = described_class.create provider: provider, status: 'draft', laa_reference: 'AAA123'
+
+      record.extended_update(ufn: '123456')
+
+      expect(record.reload.ufn).to eq '123456'
+      expect(record.laa_reference).to eq 'AAA123'
+    end
+
+    it 'ensures a unique LAA reference' do
+      provider = create(:provider)
+      PriorAuthorityApplication.create! provider: provider, laa_reference: 'LAA-123456'
+      record = PriorAuthorityApplication.create(provider: provider, status: 'pre_draft').becomes(described_class)
+
+      allow(SecureRandom).to receive(:base58).with(6).and_return('123456', '987654')
+
+      record.extended_update(ufn: '123456')
+
+      expect(record.reload.ufn).to eq '123456'
+      expect(record.laa_reference).to eq 'LAA-987654'
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
   config.include(ActiveSupport::Testing::TimeHelpers)
   config.include(Devise::Test::ControllerHelpers, type: :controller)
   config.include(AuthenticationHelpers, type: :controller)
+  config.include(AuthenticationHelpers, type: :system)
   config.include RSpecHtmlMatchers
   config.include FactoryBot::Syntax::Methods
 
@@ -43,4 +44,11 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.max_formatted_output_length = nil
   end
+end
+
+Capybara.configure do |config|
+  # Allow us to use the `choose(label_text)` method in browser tests
+  # even when the radio button element attached to the label is hidden
+  # (as it is using the standard govuk radio element)
+  config.automatic_label_click = true
 end

--- a/spec/system/prior_authority/auth_spec.rb
+++ b/spec/system/prior_authority/auth_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Prior authority authentication' do
+  context 'when user is not signed in' do
+    it 'redirects the user to the sign-in page' do
+      visit prior_authority_root_path
+      expect(page).to have_current_path '/login', ignore_query: true
+    end
+  end
+
+  context 'when user is signed in' do
+    before { visit provider_saml_omniauth_callback_path }
+
+    it 'allows the user to access the page' do
+      visit prior_authority_root_path
+      expect(page).to have_current_path prior_authority_root_path, ignore_query: true
+    end
+  end
+end

--- a/spec/system/prior_authority/case_contact_spec.rb
+++ b/spec/system/prior_authority/case_contact_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'Prior authority applications - add case contact' do
+  before do
+    visit provider_saml_omniauth_callback_path
+    visit prior_authority_root_path
+    click_on 'Start an application'
+    choose 'Yes'
+    click_on 'Save and continue'
+
+    choose 'No'
+    click_on 'Save and continue'
+
+    fill_in 'What is your unique file number?', with: '000000/123'
+    click_on 'Save and continue'
+  end
+
+  it 'allows contact detail creation' do
+    click_on 'Case contact'
+    expect(page).to have_content 'Case contact'
+    fill_in 'Full name', with: 'John Doe'
+    fill_in 'Email address', with: 'john@does.com'
+    fill_in 'Firm name', with: 'LegalCorp Ltd'
+    fill_in 'Firm account number', with: 'A12345'
+    click_on 'Save and continue'
+
+    expect(page).to have_content 'Case contact Complete'
+  end
+
+  it 'does validations' do
+    click_on 'Case contact'
+    click_on 'Save and continue'
+
+    expect(page).to have_content 'Enter the full contact name'
+  end
+
+  it 'allows save and come back later' do
+    click_on 'Case contact'
+    click_on 'Save and come back later'
+
+    expect(page).to have_content 'Case contact Incomplete'
+  end
+end

--- a/spec/system/prior_authority/create_application_spec.rb
+++ b/spec/system/prior_authority/create_application_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'Prior authority application creation' do
+  before do
+    visit provider_saml_omniauth_callback_path
+    visit prior_authority_root_path
+  end
+
+  it 'allows the user to create an application' do
+    click_on 'Start an application'
+
+    expect(page).to have_content 'Is this a Prison Law matter?'
+    choose 'Yes'
+    click_on 'Save and continue'
+
+    expect(page).to have_content 'Are you applying for a total authority of less than £500?'
+    choose 'No'
+    click_on 'Save and continue'
+
+    fill_in 'What is your unique file number?', with: '000000/123'
+    click_on 'Save and continue'
+
+    expect(page).to have_content 'Your application progress'
+    click_on 'Back to applications'
+
+    expect(page).to have_content '000000/123'
+  end
+
+  it 'performs validations' do
+    click_on 'Start an application'
+
+    click_on 'Save and continue'
+    expect(page).to have_content 'Select if this is a Prison Law matter'
+    choose 'Yes'
+    click_on 'Save and continue'
+
+    click_on 'Save and continue'
+    expect(page).to have_content 'Select if you are applying for a total authority of less than £500'
+    choose 'No'
+    click_on 'Save and continue'
+
+    click_on 'Save and continue'
+    expect(page).to have_content 'Enter your unique file number for this claim'
+  end
+
+  it 'offboards the user for small-value authorities' do
+    click_on 'Start an application'
+
+    choose 'Yes'
+    click_on 'Save and continue'
+
+    expect(page).to have_content 'Are you applying for a total authority of less than £500?'
+    choose 'Yes'
+    click_on 'Save and continue'
+
+    expect(page).to have_content 'You do not need to apply'
+  end
+end

--- a/spec/system/prior_authority/delete_application_spec.rb
+++ b/spec/system/prior_authority/delete_application_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Prior authority application deletion' do
+  before do
+    visit provider_saml_omniauth_callback_path
+    visit prior_authority_root_path
+    click_on 'Start an application'
+    choose 'Yes'
+    click_on 'Save and continue'
+
+    choose 'No'
+    click_on 'Save and continue'
+
+    fill_in 'What is your unique file number?', with: '000000/123'
+    click_on 'Save and continue'
+
+    click_on 'Back to applications'
+  end
+
+  it 'allows the user to delete an application' do
+    click_on 'Delete'
+    expect(page).to have_content 'Are you sure you want to delete this draft application?'
+    click_on 'Yes, delete it'
+    expect(page).not_to have_content '000000/123'
+  end
+
+  it 'allows the user to cancel deleting an application' do
+    click_on 'Delete'
+    expect(page).to have_content 'Are you sure you want to delete this draft application?'
+    click_on 'No, do not delete it'
+    expect(page).to have_content '000000/123'
+  end
+end


### PR DESCRIPTION
## Description of change
Added a `prior_authority_applications` table
Added some namespaced prior authority routes
Used model subclasses to enforce specific validations for specific forms
Added high-level tests

## Link to relevant ticket
[CRM457-869](https://dsdmoj.atlassian.net/browse/CRM457-869)

## Notes for reviewer
Proof of concept only, do not merge. The goals were to investigate:
- Can we add Prior Authority logic without disturbing any Non-Standard Mags logic?
- Do we need to use multi-step forms or can we just use vanilla Rails to get the same effect?

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-869]: https://dsdmoj.atlassian.net/browse/CRM457-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ