### PR TITLE
CRM457-865 - Add CNTP number to submitted email

### DIFF
--- a/app/mailers/claim_submission_mailer.rb
+++ b/app/mailers/claim_submission_mailer.rb
@@ -8,7 +8,7 @@ class ClaimSubmissionMailer < GovukNotifyRails::Mailer
       LAA_case_reference: case_reference,
       UFN: unique_file_number,
       main_defendant_name: defendant_name,
-      defendant_id: defendant_id_string,
+      defendant_reference: defendant_reference_string,
       claim_total: claim_total,
       date: submission_date,
       feedback_url: feedback_url
@@ -47,7 +47,7 @@ class ClaimSubmissionMailer < GovukNotifyRails::Mailer
   end
 
   # Markdown conditionals do not allow to format the string nicely so formatting here.
-  def defendant_id_string
+  def defendant_reference_string
     if maat_id.nil?
       "Client's CNTP number: #{cntp_order}"
     else

--- a/app/mailers/claim_submission_mailer.rb
+++ b/app/mailers/claim_submission_mailer.rb
@@ -8,7 +8,7 @@ class ClaimSubmissionMailer < GovukNotifyRails::Mailer
       LAA_case_reference: case_reference,
       UFN: unique_file_number,
       main_defendant_name: defendant_name,
-      maat_id: maat_id,
+      defendant_id: defendant_id_string,
       claim_total: claim_total,
       date: submission_date,
       feedback_url: feedback_url
@@ -40,6 +40,19 @@ class ClaimSubmissionMailer < GovukNotifyRails::Mailer
 
   def maat_id
     main_defendant.maat
+  end
+
+  def cntp_order
+    @claim.cntp_order
+  end
+
+  # Markdown conditionals do not allow to format the string nicely so formatting here.
+  def defendant_id_string
+    if maat_id.nil?
+      "Client's CNTP number: #{cntp_order}"
+    else
+      "MAAT ID: #{maat_id}"
+    end
   end
 
   def claim_total

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -46,6 +46,10 @@ FactoryBot.define do
       defendants { [build(:defendant, :valid)] }
     end
 
+    trait :breach_defendant do
+      defendants { [build(:defendant, :partial)] }
+    end
+
     trait :case_details do
       ufn { '20150612/001' }
       main_offence { MainOffence.all.sample.name }

--- a/spec/mailers/claim_submission_mailer_spec.rb
+++ b/spec/mailers/claim_submission_mailer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
           LAA_case_reference: 'LAA-n4AohV',
           UFN: '123456/001',
           main_defendant_name: 'bobjim',
-          defendant_id: 'MAAT ID: AA1',
+          defendant_reference: 'MAAT ID: AA1',
           claim_total: '£20.45',
           date: DateTime.now.strftime('%d %B %Y'),
           feedback_url: 'tbc'
@@ -49,7 +49,7 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
           LAA_case_reference: 'LAA-n4AohV',
           UFN: '123456/002',
           main_defendant_name: 'bobjim',
-          defendant_id: "Client's CNTP number: CNTP12345",
+          defendant_reference: "Client's CNTP number: CNTP12345",
           claim_total: '£20.45',
           date: DateTime.now.strftime('%d %B %Y'),
           feedback_url: 'tbc'

--- a/spec/mailers/claim_submission_mailer_spec.rb
+++ b/spec/mailers/claim_submission_mailer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
       ).to eq feedback_template
     end
 
-    context 'with personalisation' do
+    context 'defendant with maat id' do
       it 'sets personalisation from args' do
         expect(
           mail.govuk_notify_personalisation
@@ -31,11 +31,28 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
           LAA_case_reference: 'LAA-n4AohV',
           UFN: '123456/001',
           main_defendant_name: 'bobjim',
-          maat_id: 'AA1',
+          defendant_id: 'MAAT ID: AA1',
           claim_total: '£20.45',
           date: DateTime.now.strftime('%d %B %Y'),
           feedback_url: 'tbc'
         )
+      end
+    end
+
+    context 'defendant with cntp id' do
+      let(:claim) { build(:claim, :case_type_breach, :breach_defendant, :letters_calls) }
+      it 'sets personalisation from args' do
+        expect(
+          mail.govuk_notify_personalisation
+        ).to include(
+               LAA_case_reference: 'LAA-n4AohV',
+               UFN: '123456/002',
+               main_defendant_name: 'bobjim',
+               defendant_id: "Client's CNTP number: CNTP12345",
+               claim_total: '£20.45',
+               date: DateTime.now.strftime('%d %B %Y'),
+               feedback_url: 'tbc'
+             )
       end
     end
   end

--- a/spec/mailers/claim_submission_mailer_spec.rb
+++ b/spec/mailers/claim_submission_mailer_spec.rb
@@ -41,18 +41,19 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
 
     context 'defendant with cntp id' do
       let(:claim) { build(:claim, :case_type_breach, :breach_defendant, :letters_calls) }
+
       it 'sets personalisation from args' do
         expect(
           mail.govuk_notify_personalisation
         ).to include(
-               LAA_case_reference: 'LAA-n4AohV',
-               UFN: '123456/002',
-               main_defendant_name: 'bobjim',
-               defendant_id: "Client's CNTP number: CNTP12345",
-               claim_total: '£20.45',
-               date: DateTime.now.strftime('%d %B %Y'),
-               feedback_url: 'tbc'
-             )
+          LAA_case_reference: 'LAA-n4AohV',
+          UFN: '123456/002',
+          main_defendant_name: 'bobjim',
+          defendant_id: "Client's CNTP number: CNTP12345",
+          claim_total: '£20.45',
+          date: DateTime.now.strftime('%d %B %Y'),
+          feedback_url: 'tbc'
+        )
       end
     end
   end


### PR DESCRIPTION
## Description of change

- Adds conditional so send Maat or CNTP depending on the claim type

## Link to relevant ticket

[CRM457-865](https://dsdmoj.atlassian.net/browse/CRM457-865)

## Notes for reviewer

Limitations within the notify service means that conditionals and optional content is not easy within the template and thus i have opted to do this within the code itself. 

## Screenshots of changes (if applicable)

![Screenshot 2024-01-15 at 14 42 43](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/fb5517e3-08f2-4fb4-967c-fc31f1593029)
![Screenshot 2024-01-15 at 14 42 18](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/84575729/4d43cedd-c632-429a-8fab-ff76f54c4956)


[CRM457-865]: https://dsdmoj.atlassian.net/browse/CRM457-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ