### PR TITLE
Output rspec results on CI and store coverage artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,21 +133,28 @@ commands:
 
   rspec:
     steps:
+      - save_cache:
+          key: nsmf-claim-repo-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/repo
       - db-setup
       - run:
           name: Run rspec tests
           command: |
-            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
             RUBYOPT=-W:no-deprecated \
             bundle exec rspec \
              --format progress \
-             --out /tmp/test-results/rspec.xml \
-              $TESTFILES
+             --format RspecJunitFormatter \
+             --out /tmp/test-results/rspec/rspec.xml \
+            -- ${TESTFILES}
       - store_test_results:
-          path: /tmp/test-results
+          path: /tmp/test-results/rspec
+      - restore_cache:
+          key: nsmf-claim-repo-{{ .Environment.CIRCLE_SHA1 }}
       - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
+          path: ~/repo/coverage
+          destination: coverage
 
   build-docker-image:
       steps:

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'erb_lint', require: false
   gem 'pry'
   gem 'rspec-expectations'
+  gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 6.1.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,8 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.60.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -529,6 +531,7 @@ DEPENDENCIES
   rspec-expectations
   rspec-html-matchers
   rspec-rails (~> 6.1.0)
+  rspec_junit_formatter
   rubocop
   rubocop-performance
   rubocop-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,11 @@ unless ENV['NOCOVERAGE']
     add_filter 'app/jobs/application_job.rb'
     add_filter 'app/mailers/application_mailer.rb'
 
+    add_group 'Forms', '/app/forms'
+    add_group 'Presenters', '/app/presenters'
+    add_group 'Services', '/app/services'
+    add_group 'Value objects', '/app/value_objects'
+
     enable_coverage :branch
     primary_coverage :branch
     minimum_coverage branch: 100, line: 100


### PR DESCRIPTION
## Description of change
Output rspec results on CI and store coverage artifact

So we can see rspec failures on CI and store
coverage results for our perusal.

## Link to relevant ticket
Came out of work on [CRM457-869](https://dsdmoj.atlassian.net/browse/CRM457-869) when trying to check coverage

## Notes for reviewer
You can see the coverage in the artifact tab on Circle CI. Just click coverage/index.html

## Screenshots of changes (if applicable)
**Failing test now visible**
<img width="1451" alt="Screenshot 2024-01-17 at 14 54 56" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/7016425/d363b588-00f5-425b-b1d6-cc404681a594">

**Coverage artifact available**
<img width="1440" alt="Screenshot 2024-01-17 at 14 47 02" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/7016425/5c10c64d-678f-4718-a5f7-37f7418f2e45">



[CRM457-869]: https://dsdmoj.atlassian.net/browse/CRM457-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ