### PR TITLE
CRM457-946: multi stage form specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,13 @@ commands:
           path: ~/repo/coverage
           destination: coverage
 
+  rspec-gem-specs:
+    steps:
+      - run:
+          name: Run rspec tests
+          command: |
+            bundle exec rspec
+
   build-docker-image:
       steps:
         - run:
@@ -237,6 +244,15 @@ jobs:
       - browser-tools/install-browser-tools
       - rspec
 
+  rspec-gem-tests:
+    executor: test-executor
+    working_directory: ~/repo/gems/laa_multi_step_forms
+    steps:
+      - checkout:
+          path: ~/repo
+      - install-gems
+      - rspec-gem-specs
+
   scan-docker-image:
     executor: test-executor
     parallelism: 1
@@ -317,6 +333,9 @@ workflows:
           requires:
             - build-test-container
       - rspec-tests:
+          requires:
+            - build-test-container
+      - rspec-gem-tests:
           requires:
             - build-test-container
       - scan-docker-image:

--- a/gems/laa_multi_step_forms/Gemfile
+++ b/gems/laa_multi_step_forms/Gemfile
@@ -17,6 +17,7 @@ group :development, :test do
 end
 
 group :test do
+  gem 'pg', '~> 1.5'
   gem 'rails-controller-testing'
   gem 'rspec-html-matchers'
   gem 'rubocop', require: false

--- a/gems/laa_multi_step_forms/Gemfile.lock
+++ b/gems/laa_multi_step_forms/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     parallel (1.23.0)
     parser (3.2.2.1)
       ast (~> 2.4.1)
+    pg (1.5.4)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -315,6 +316,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
 
@@ -322,6 +324,7 @@ DEPENDENCIES
   debug
   hmcts_common_platform!
   laa_multi_step_forms!
+  pg (~> 1.5)
   pry
   rails-controller-testing
   rspec-html-matchers

--- a/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/downloadable_entity_controller.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/app/controllers/steps/downloadable_entity_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  class DownloadableEntityController < Steps::BaseStepController
+    def download; end
+
+    private
+
+    def decision_tree_class; end
+  end
+end

--- a/gems/laa_multi_step_forms/spec/dummy/config/routes.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
         end
       end
       upload_step :supporting_evidence
+      upload_step :downloadable_entity do
+        collection { get :download }
+      end
     end
   end
 end

--- a/gems/laa_multi_step_forms/spec/helpers/application_helper_spec.rb
+++ b/gems/laa_multi_step_forms/spec/helpers/application_helper_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe LaaMultiStepForms::ApplicationHelper, type: :helper do
 
     context 'when period is not nil' do
       it 'formats the value in hours and minutes' do
-        expect(helper.format_period(62)).to eq('1 Hr 2 Mins')
+        expect(helper.format_period(62)).to eq('1 Hour 2 Mins')
         expect(helper.format_period(1)).to eq('0 Hours 1 Min')
       end
     end

--- a/gems/laa_multi_step_forms/spec/lib/routes_helpers_spec.rb
+++ b/gems/laa_multi_step_forms/spec/lib/routes_helpers_spec.rb
@@ -63,5 +63,8 @@ RSpec.describe RouteHelpers, type: :routing do
     expect(delete("/applications/#{id}/steps/supporting_evidence")).to route_to(
       'steps/supporting_evidence#destroy', id:
     )
+    expect(get("/applications/#{id}/steps/downloadable_entity/download")).to route_to(
+      'steps/downloadable_entity#download', id:
+    )
   end
 end

--- a/gems/laa_multi_step_forms/spec/value_objects/value_object_spec.rb
+++ b/gems/laa_multi_step_forms/spec/value_objects/value_object_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe ValueObject do
     it 'has a constant with the inquiry methods' do
       expect(
         YesNoAnswer::INQUIRY_METHODS
-      ).to match_array(%i[yes? no?])
+      ).to match_array(%w[yes? no?])
     end
 
     it 'defines inquiry methods for each of the values' do


### PR DESCRIPTION
## Description of change
* Fixed broken specs in multi-stage form gem
* Got branch coverage up to 100%
* Added multi-stage form gem specs to CI so we notice if they break again.

## Link to relevant ticket
[JIRA](https://dsdmoj.atlassian.net/browse/CRM457-946)

## Notes for reviewer
* I had to add the 'pg' gem as a dependency to the Gemfile because the tests specify dummy models that inherit from ActiveRecord::Base, and RSpec throws a wobbly on CI without a database adapter
* The dummy router used in the tests has one of most types of custom routing steps; all it was missing was an upload step

## Screenshots of changes (if applicable)
N/A

## How to manually test the feature
N/A
