### PR TITLE
Add overcommit with rubocop

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,56 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+#PreCommit:
+#  RuboCop:
+#    enabled: true
+#    on_warn: fail # Treat all warnings as failures
+#
+#  TrailingWhitespace:
+#    enabled: true
+#    exclude:
+#      - '**/db/structure.sql' # Ignore trailing whitespace in generated files
+#
+#PostCheckout:
+#  ALL: # Special hook name that customizes all hooks of this type
+#    quiet: true # Change all post-checkout hooks to only display output on failure
+#
+#  IndexTags:
+#    enabled: true # Generate a tags file with `ctags` each time HEAD changes
+
+CommitMsg:
+  ALL:
+    requires_files: false
+    quiet: true
+
+  CapitalizedSubject:
+    enabled: false
+
+  SingleLineSubject:
+    enabled: false
+
+  TextWidth:
+    enabled: false
+
+  TrailingPeriod:
+    enabled: false
+
+PreCommit:
+  RuboCop:
+    enabled: true
+    command: ['bundle', 'exec', 'rubocop']
+    requires_files: true

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri windows]
   gem 'dotenv-rails'
   gem 'erb_lint', require: false
+  gem 'overcommit'
   gem 'pry'
   gem 'rspec-expectations'
   gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.0.0)
     clamby (1.6.10)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
@@ -226,6 +227,7 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
+    iniparse (1.5.0)
     io-console (0.7.1)
     irb (1.11.1)
       rdoc
@@ -288,6 +290,10 @@ GEM
       ruby-saml (~> 1.12)
     optimist (3.0.1)
     orm_adapter (0.5.0)
+    overcommit (0.62.0)
+      childprocess (>= 0.6.3, < 6)
+      iniparse (~> 1.4)
+      rexml (~> 3.2)
     pagy (6.4.3)
     parallel (1.24.0)
     parser (3.3.0.4)
@@ -522,6 +528,7 @@ DEPENDENCIES
   laa_multi_step_forms!
   logstasher (~> 2.1)
   oauth2 (~> 2.0)
+  overcommit
   pagy (~> 6.4.3)
   pg (~> 1.5)
   pry


### PR DESCRIPTION
## Description of change
Add overcommit and have it run rubocop pre-commit

You can choose to activate it locally or not

```sh
bundle install
overcommit --install
```

Currently it will only run rubocop and commit message linting before any commit. You can prevent it doing so on a per commit basis even when activate using...

```sh
git commit -n ...
```

when changes are made to the `.overcommit.yml` by yourself
or another dev (which you then pull locally) you may be prompted
to "sign" the changes. This is expected behaviour.

```sh
overcommit --sign
```
