### PR TITLE
Add omniauth logging and silence test output

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,6 +3,7 @@ require Rails.root.join('app/lib/laa_portal/saml_strategy')
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   configure do |config|
+    config.logger = Rails.logger
     config.logger.level = Logger::WARN if Rails.env.test?
     config.add_mock(:saml, LaaPortal::SamlStrategy.mock_auth)
     config.test_mode = Rails.env.test? || ENV.fetch('OMNIAUTH_TEST_MODE', 'false').inquiry.true?


### PR DESCRIPTION
## Description of change
Add omniauth logging and silence test output

without this the omniauth logs will got to STDOUT
and, for testing, that means we pollute the test output.

Example test output without this
```sh
E, [2024-01-22T12:54:47.079992 #66377] ERROR -- omniauth: (saml) Authentication failure! StandardError: StandardError, StandardError
```
