### PR TITLE
Use govuk_phase_banner component

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   service:
     name: Claim a non-standard magistrates' court payment
-  
+
   views:
     pagination:
       title: "Pagination navigation"
@@ -12,7 +12,7 @@ en:
       next_html: "<span class='govuk-pagination__link-title'>Next <span class='govuk-visually-hidden'>page</span></span><svg class='govuk-pagination__icon govuk-pagination__icon--next' xmlns='http://www.w3.org/2000/svg' height='13' width='15' aria-hidden='true' focusable='false' viewBox='0 0 15 13'><path d='m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z'></path></svg>"
       truncate: "&hellip;"
       page_html: "<span class='govuk-visually-hidden'>Page </span>%{count}"
-  
+
   flash:
     success:
       title: Success
@@ -31,4 +31,4 @@ en:
       sign_out: Sign out
     phase_banner:
       phase: Beta
-      phase_description: This is a new service – your <a class="govuk-link" href="%{feedback}">feedback</a> will help us to improve it.
+      phase_description_html: This is a new service – your <a class="govuk-link" href="%{feedback}">feedback</a> will help us to improve it.

--- a/gems/laa_multi_step_forms/app/helpers/laa_multi_step_forms/application_helper.rb
+++ b/gems/laa_multi_step_forms/app/helpers/laa_multi_step_forms/application_helper.rb
@@ -26,6 +26,12 @@ module LaaMultiStepForms
       "app-environment-#{ENV.fetch('ENV', 'local')}"
     end
 
+    def phase_name
+      return t('layouts.phase_banner.phase') if ENV.fetch('ENV', 'local') == 'production'
+
+      ENV.fetch('ENV', 'local').capitalize
+    end
+
     def format_period(period)
       return if period.nil?
 

--- a/gems/laa_multi_step_forms/app/views/layouts/_phase_banner.html.erb
+++ b/gems/laa_multi_step_forms/app/views/layouts/_phase_banner.html.erb
@@ -1,14 +1,2 @@
-<div class="govuk-phase-banner" role="complementary">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      <% if ENV.fetch('ENV', 'local') == 'production' %>
-        <%= t('.phase') %>
-      <% else %>
-        <%= ENV.fetch('ENV', 'local').capitalize %>
-      <% end %>
-    </strong>
-    <span class="govuk-phase-banner__text">
-      <%= t('.phase_description', feedback: main_app.about_feedback_index_path).html_safe %>
-    </span>
-  </p>
-</div>
+<%= govuk_phase_banner(tag: { text: phase_name },
+                       text: t('.phase_description_html', feedback: main_app.about_feedback_index_path)) %>

--- a/gems/laa_multi_step_forms/config/locales/en/layouts.yml
+++ b/gems/laa_multi_step_forms/config/locales/en/layouts.yml
@@ -1,0 +1,5 @@
+---
+en:
+  layouts:
+    phase_banner:
+      phase: Beta

--- a/gems/laa_multi_step_forms/spec/helpers/application_helper_spec.rb
+++ b/gems/laa_multi_step_forms/spec/helpers/application_helper_spec.rb
@@ -51,22 +51,49 @@ RSpec.describe LaaMultiStepForms::ApplicationHelper, type: :helper do
   end
 
   describe '#app_environment' do
-    context 'when ENV is set' do
-      around do |spec|
-        env = ENV.fetch('ENV', nil)
-        ENV['ENV'] = 'test'
-        spec.run
-        ENV['ENV'] = env
+    context 'when ENV var "ENV" is set' do
+      before do
+        allow(ENV).to receive(:fetch).with('ENV', 'local').and_return 'test'
       end
 
-      it 'returns based on ENV variable' do
+      it 'returns based on ENV var "ENV" variable' do
         expect(helper.app_environment).to eq('app-environment-test')
       end
     end
 
-    context 'when ENV is not set' do
-      it 'returns based with local' do
+    context 'when ENV var "ENV" is not set' do
+      it 'returns based on local' do
         expect(helper.app_environment).to eq('app-environment-local')
+      end
+    end
+  end
+
+  describe '#phase_name' do
+    subject(:phase_name) { helper.phase_name }
+
+    context 'when ENV var "ENV" is production' do
+      before do
+        allow(ENV).to receive(:fetch).with('ENV', 'local').and_return 'production'
+      end
+
+      it 'returns Beta' do
+        expect(phase_name).to eql 'Beta'
+      end
+    end
+
+    context 'when ENV var "ENV" returns something other than production' do
+      before do
+        allow(ENV).to receive(:fetch).with('ENV', 'local').and_return 'uat'
+      end
+
+      it 'returns the ENV var value' do
+        expect(phase_name).to eql 'Uat'
+      end
+    end
+
+    context 'when ENV var "ENV" is not set' do
+      it 'returns "local"' do
+        expect(phase_name).to eql 'Local'
       end
     end
   end


### PR DESCRIPTION
## Description of change
Use govuk_phase_banner component

Simplify the partial to use the govuk-component
libraries phase banner component. For brevity and to
delegate styling out to this well maintained gem.
