### PR TITLE
CRM457-975: Prior authority error message updates

### DIFF
--- a/app/controllers/prior_authority/steps/authority_value_controller.rb
+++ b/app/controllers/prior_authority/steps/authority_value_controller.rb
@@ -1,16 +1,16 @@
 module PriorAuthority
   module Steps
     class AuthorityValueController < BaseController
-      def edit
-        @authority_threshold = current_application.prison_law? ? 500 : 100
+      before_action :set_authority_threshold
 
+      def edit
         @form_object = AuthorityValueForm.build(
           current_application
         )
       end
 
       def update
-        @form_object = current_application.becomes(AuthorityValueForm)
+        @form_object = AuthorityValueForm.build(current_application)
         @form_object.assign_attributes(allowed_params)
 
         if @form_object.valid?
@@ -32,6 +32,10 @@ module PriorAuthority
 
       def as
         :authority_value
+      end
+
+      def set_authority_threshold
+        @authority_threshold = current_application.prison_law? ? 500 : 100
       end
     end
   end

--- a/app/forms/prior_authority/steps/authority_value_form.rb
+++ b/app/forms/prior_authority/steps/authority_value_form.rb
@@ -2,10 +2,22 @@ module PriorAuthority
   module Steps
     class AuthorityValueForm < ::Steps::BaseFormObject
       attribute :authority_value, :boolean
-      validates :authority_value, inclusion: { in: [true, false] }
+      validate :authority_value_inclusion_with_threshold
 
       def persist!
         application.update!(attributes)
+      end
+
+      private
+
+      def authority_value_inclusion_with_threshold
+        return if authority_value.in?([true, false])
+
+        if application.prison_law?
+          errors.add(:authority_value, :'inclusion.less_than_five_hundred')
+        else
+          errors.add(:authority_value, :'inclusion.less_than_one_hundred')
+        end
       end
     end
   end

--- a/app/views/prior_authority/applications/offboard.html.erb
+++ b/app/views/prior_authority/applications/offboard.html.erb
@@ -2,7 +2,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
-    <p class="govuk-text"><%= t('.explanation') %></p>
+    <% if current_application.prison_law? %>
+      <p class="govuk-text"><%= t(".explanation.prison_law.yes") %></p>
+    <% else %>
+      <p class="govuk-text"><%= t(".explanation.prison_law.no") %></p>
+    <% end %>
     <%= link_to t('.finish'), prior_authority_root_path, class: 'govuk-button' %>
   </div>
 </div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -61,7 +61,14 @@ en:
               blank: Enter the client's first name
             client_last_name:
               blank: Enter the client's last name
-            client_date_of_birth: *shared_date_errors
+            client_date_of_birth:
+              blank: Enter the client's date of birth
+              invalid: Enter a valid date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
+              year_too_early: Client's date of birth is too far in the past
+              future_not_allowed: Client's date of birth cannot be in the future
         prior_authority/steps/case_contact/firm_detail_form:
           attributes:
             name:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -46,7 +46,9 @@ en:
         prior_authority/steps/authority_value_form:
           attributes:
             authority_value:
-              inclusion: Select if you are applying for a total authority of less than £500
+              inclusion:
+                less_than_five_hundred: Select yes if you are applying for a total authority of less than £500
+                less_than_one_hundred: Select yes if you are applying for a total authority of less than £100
         prior_authority/steps/case_contact_form:
           attributes:
             contact_name:

--- a/config/locales/en/prior_authority.yml
+++ b/config/locales/en/prior_authority.yml
@@ -30,7 +30,10 @@ en:
         no_delete: "No, do not delete it"
       offboard:
         page_title: You do not need to apply
-        explanation: You do not need to apply for prior authority to incur disbursements for a Prison Law matter if the total authority is less than £500.
+        explanation:
+          prison_law:
+            'no': You do not need to apply for prior authority to incur disbursements if the total authority is less than £100.
+            'yes': You do not need to apply for prior authority to incur disbursements for a Prison Law matter if the total authority is less than £500.
         finish: 'Finish'
     steps:
       start_page:

--- a/spec/forms/prior_authority/steps/authority_value_form_spec.rb
+++ b/spec/forms/prior_authority/steps/authority_value_form_spec.rb
@@ -25,14 +25,29 @@ RSpec.describe PriorAuthority::Steps::AuthorityValueForm do
       it { is_expected.to be_valid }
     end
 
-    context 'with blank authority value value ufn' do
+    context 'with blank authority value for prison law matter' do
       let(:authority_value) { '' }
+
+      before { allow(application).to receive(:prison_law?).and_return true }
 
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:authority_value, :inclusion)).to be(true)
+        expect(form.errors.of_kind?(:authority_value, :'inclusion.less_than_five_hundred')).to be(true)
         expect(form.errors.messages[:authority_value])
-          .to include('Select if you are applying for a total authority of less than £500')
+          .to include('Select yes if you are applying for a total authority of less than £500')
+      end
+    end
+
+    context 'with blank authority value but not prison law matter' do
+      let(:authority_value) { '' }
+
+      before { allow(application).to receive(:prison_law?).and_return false }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:authority_value, :'inclusion.less_than_one_hundred')).to be(true)
+        expect(form.errors.messages[:authority_value])
+          .to include('Select yes if you are applying for a total authority of less than £100')
       end
     end
   end

--- a/spec/forms/prior_authority/steps/client_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/client_detail_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PriorAuthority::Steps::ClientDetailForm do
   describe '#validate' do
     let(:application) { instance_double(PriorAuthorityApplication) }
 
-    context 'with valid format of ufn' do
+    context 'with valid client details' do
       let(:client_first_name) { 'Joe' }
       let(:client_last_name) { 'Bloggs' }
       let(:client_date_of_birth) { 20.years.ago.to_date }
@@ -28,14 +28,15 @@ RSpec.describe PriorAuthority::Steps::ClientDetailForm do
       let(:client_last_name) { '' }
       let(:client_date_of_birth) { '' }
 
-      it 'has a validation error on the field' do
+      it 'has a validation errors on the fields' do
         expect(form).not_to be_valid
         expect(form.errors.of_kind?(:client_first_name, :blank)).to be(true)
         expect(form.errors.of_kind?(:client_last_name, :blank)).to be(true)
         expect(form.errors.of_kind?(:client_date_of_birth, :blank)).to be(true)
-        expect(form.errors.messages.values.flatten).to include("Enter the client's first name",
-                                                               "Enter the client's first name",
-                                                               'Date cannot be blank')
+        expect(form.errors.messages.values.flatten)
+          .to include("Enter the client's first name",
+                      "Enter the client's last name",
+                      "Enter the client's date of birth")
       end
     end
   end

--- a/spec/system/prior_authority/authority_value_spec.rb
+++ b/spec/system/prior_authority/authority_value_spec.rb
@@ -10,14 +10,17 @@ RSpec.describe 'Prior authority applications - add case contact' do
   context 'when application relates to a prison law matter' do
     it 'set authority threshold to £500' do
       expect(page).to have_content 'Is this a Prison Law matter?'
+
       choose 'Yes'
       click_on 'Save and continue'
-
       expect(page).to have_content 'Are you applying for a total authority of less than £500?'
+
+      click_on 'Save and continue'
+      expect(page)
+        .to have_content 'Select yes if you are applying for a total authority of less than £500'
 
       choose 'No'
       click_on 'Save and continue'
-
       expect(page).to have_title 'Unique file number'
     end
   end
@@ -27,12 +30,14 @@ RSpec.describe 'Prior authority applications - add case contact' do
       expect(page).to have_content 'Is this a Prison Law matter?'
       choose 'No'
       click_on 'Save and continue'
-
       expect(page).to have_content 'Are you applying for a total authority of less than £100?'
+
+      click_on 'Save and continue'
+      expect(page)
+        .to have_content 'Select yes if you are applying for a total authority of less than £100'
 
       choose 'No'
       click_on 'Save and continue'
-
       expect(page).to have_title 'Unique file number'
     end
   end

--- a/spec/system/prior_authority/client_detail_spec.rb
+++ b/spec/system/prior_authority/client_detail_spec.rb
@@ -30,16 +30,18 @@ RSpec.describe 'Prior authority applications - add client details' do
 
     fill_in 'First name', with: 'John'
     fill_in 'Last name', with: 'Doe'
-    fill_in 'prior_authority_steps_client_detail_form_client_date_of_birth_3i', with: '27'
-    fill_in 'prior_authority_steps_client_detail_form_client_date_of_birth_2i', with: '12'
-    fill_in 'prior_authority_steps_client_detail_form_client_date_of_birth_1i', with: '2000'
+    within('.govuk-form-group', text: 'Date of birth') do
+      fill_in 'Day', with: '27'
+      fill_in 'Month', with: '12'
+      fill_in 'Year', with: '2000'
+    end
+
     click_on 'Save and come back later'
 
     expect(page).to have_content 'Client detailsCompleted'
 
     click_on 'Client details'
     click_on 'Save and continue'
-    # TODO: expect(page).to have_title 'Case details'
   end
 
   it 'validates client detail fields' do
@@ -49,7 +51,7 @@ RSpec.describe 'Prior authority applications - add client details' do
     click_on 'Save and continue'
     expect(page).to have_content "Enter the client's first name"
     expect(page).to have_content "Enter the client's last name"
-    expect(page).to have_content 'Date cannot be blank'
+    expect(page).to have_content "Enter the client's date of birth"
   end
 
   it 'allows save and come back later' do

--- a/spec/system/prior_authority/create_application_spec.rb
+++ b/spec/system/prior_authority/create_application_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Prior authority application creation' do
     expect(page).to have_content 'Enter your unique file number for this application'
   end
 
-  it 'offboards the user for small-value authorities' do
+  it 'offboards the user for authority request of less than £500' do
     click_on 'Start an application'
 
     choose 'Yes'
@@ -52,7 +52,22 @@ RSpec.describe 'Prior authority application creation' do
     expect(page).to have_content 'Are you applying for a total authority of less than £500?'
     choose 'Yes'
     click_on 'Save and continue'
+    expect(page).to have_title 'You do not need to apply'
+    expect(page)
+      .to have_content 'to incur disbursements for a Prison Law matter if the total authority is less than £500.'
+  end
 
-    expect(page).to have_content 'You do not need to apply'
+  it 'offboards the user for authority request of less than £100' do
+    click_on 'Start an application'
+
+    choose 'No'
+    click_on 'Save and continue'
+
+    expect(page).to have_content 'Are you applying for a total authority of less than £100?'
+    choose 'Yes'
+    click_on 'Save and continue'
+    expect(page).to have_title 'You do not need to apply'
+    expect(page)
+      .to have_content 'to incur disbursements if the total authority is less than £100.'
   end
 end

--- a/spec/system/prior_authority/create_application_spec.rb
+++ b/spec/system/prior_authority/create_application_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Prior authority application creation' do
     click_on 'Save and continue'
 
     click_on 'Save and continue'
-    expect(page).to have_content 'Select if you are applying for a total authority of less than £500'
+    expect(page).to have_content 'Select yes if you are applying for a total authority of less than £500'
     choose 'No'
     click_on 'Save and continue'
 


### PR DESCRIPTION
## Description of change
Amend error messages inline with designs

- Authority value: Conditional error message for authority value
based on the preceding prison law matter question.
- Client details: more customised date errors inline with designs

Also, 

- Amend conditional offboarding page content depending on prison law matter answer (see  [CRM457-973](https://dsdmoj.atlassian.net/browse/CRM457-973))
 

## Link to relevant ticket

Error messages taken from [this spreadsheet](https://docs.google.com/spreadsheets/d/1p79PoMhECgMiCDB_qQGTvCALflGjiHMDnPNA8n7mtcc/edit#gid=1083653105) that is attached to this ticket [CRM457-975](https://dsdmoj.atlassian.net/browse/CRM457-975)


[CRM457-975]: https://dsdmoj.atlassian.net/browse/CRM457-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CRM457-973]: https://dsdmoj.atlassian.net/browse/CRM457-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ