### PR TITLE
Crm457 957 reuse defendants

### DIFF
--- a/app/controllers/prior_authority/steps/client_detail_controller.rb
+++ b/app/controllers/prior_authority/steps/client_detail_controller.rb
@@ -3,18 +3,24 @@ module PriorAuthority
     class ClientDetailController < BaseController
       def edit
         @form_object = ClientDetailForm.build(
-          current_application
+          defendant,
+          application: current_application
         )
       end
 
       def update
-        update_and_advance(ClientDetailForm, as:, after_commit_redirect_path:)
+        record = defendant
+        update_and_advance(ClientDetailForm, as:, after_commit_redirect_path:, record:)
       end
 
       private
 
       def as
         :client_detail
+      end
+
+      def defendant
+        current_application.defendant || current_application.build_defendant
       end
     end
   end

--- a/app/forms/nsm/steps/defendant_details_form.rb
+++ b/app/forms/nsm/steps/defendant_details_form.rb
@@ -1,10 +1,12 @@
 module Nsm
   module Steps
     class DefendantDetailsForm < ::Steps::BaseFormObject
-      attribute :full_name, :string
+      attribute :first_name, :string
+      attribute :last_name, :string
       attribute :maat, :string
 
-      validates :full_name, presence: true
+      validates :first_name, presence: true
+      validates :last_name, presence: true
       validates :maat, presence: true, if: :maat_required?
 
       def maat_required?

--- a/app/forms/prior_authority/steps/client_detail_form.rb
+++ b/app/forms/prior_authority/steps/client_detail_form.rb
@@ -1,18 +1,18 @@
 module PriorAuthority
   module Steps
     class ClientDetailForm < ::Steps::BaseFormObject
-      attribute :client_first_name, :string
-      attribute :client_last_name, :string
-      attribute :client_date_of_birth, :multiparam_date
+      attribute :first_name, :string
+      attribute :last_name, :string
+      attribute :date_of_birth, :multiparam_date
 
-      validates :client_first_name, presence: true
-      validates :client_last_name, presence: true
-      validates :client_date_of_birth, presence: true, multiparam_date: { allow_past: true, allow_future: false }
+      validates :first_name, presence: true
+      validates :last_name, presence: true
+      validates :date_of_birth, presence: true, multiparam_date: { allow_past: true, allow_future: false }
 
       private
 
       def persist!
-        application.update!(attributes)
+        record.update!(attributes)
       end
     end
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -4,7 +4,9 @@ class Claim < ApplicationRecord
   belongs_to :solicitor, optional: true
   has_many :cost_totals, -> { order(:id) }, dependent: :destroy, inverse_of: :claim
   has_many :defendants, -> { order(:position) }, dependent: :destroy, as: :defendable, inverse_of: :defendable
-  has_one :main_defendant, -> { where(main: true) }, class_name: 'Defendant', dependent: nil, as: :defendable, inverse_of: :defendable
+  has_one :main_defendant, lambda {
+                             where(main: true)
+                           }, class_name: 'Defendant', dependent: nil, as: :defendable, inverse_of: :defendable
   has_many :work_items, -> { order(:completed_on, :work_type, :id) }, dependent: :destroy, inverse_of: :claim
   has_many :disbursements, lambda {
                              order(:disbursement_date, :disbursement_type, :id)

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -3,8 +3,8 @@ class Claim < ApplicationRecord
   belongs_to :firm_office, optional: true
   belongs_to :solicitor, optional: true
   has_many :cost_totals, -> { order(:id) }, dependent: :destroy, inverse_of: :claim
-  has_many :defendants, -> { order(:position) }, dependent: :destroy, inverse_of: :claim
-  has_one :main_defendant, -> { where(main: true) }, class_name: 'Defendant', dependent: nil, inverse_of: :claim
+  has_many :defendants, -> { order(:position) }, dependent: :destroy, as: :defendable, inverse_of: :defendable
+  has_one :main_defendant, -> { where(main: true) }, class_name: 'Defendant', dependent: nil, as: :defendable, inverse_of: :defendable
   has_many :work_items, -> { order(:completed_on, :work_type, :id) }, dependent: :destroy, inverse_of: :claim
   has_many :disbursements, lambda {
                              order(:disbursement_date, :disbursement_type, :id)

--- a/app/models/defendant.rb
+++ b/app/models/defendant.rb
@@ -1,7 +1,11 @@
 # NOTE: position value is used purely to maintain insertion order
 # and is not used to number or identify the defendant.
 class Defendant < ApplicationRecord
-  belongs_to :claim
+  belongs_to :defendable, polymorphic: true
 
   validates :id, exclusion: { in: [Nsm::StartPage::NEW_RECORD] }
+
+  def full_name
+    [first_name, last_name].join(' ')
+  end
 end

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -2,6 +2,7 @@ class PriorAuthorityApplication < ApplicationRecord
   belongs_to :provider
   belongs_to :firm_office, optional: true
   belongs_to :solicitor, optional: true
+  has_one :defendant, dependent: :destroy, as: :defendable
 
   attribute :prison_law, :boolean
   attribute :ufn, :string

--- a/app/presenters/prior_authority/tasks/client_detail.rb
+++ b/app/presenters/prior_authority/tasks/client_detail.rb
@@ -9,6 +9,10 @@ module PriorAuthority
       def path
         edit_prior_authority_steps_client_detail_path(application)
       end
+
+      def completed?
+        application.defendant && super(application.defendant)
+      end
     end
   end
 end

--- a/app/services/notify_app_store/message_builder.rb
+++ b/app/services/notify_app_store/message_builder.rb
@@ -69,7 +69,7 @@ class NotifyAppStore
 
     def defendant_data
       claim.defendants.map do |defendant|
-        defendant.as_json.slice!(*DEFAULT_IGNORE)
+        defendant.as_json(only: %i[id maat main position]).merge('full_name' => defendant.full_name)
       end
     end
 

--- a/app/views/nsm/steps/defendant_details/edit.html.erb
+++ b/app/views/nsm/steps/defendant_details/edit.html.erb
@@ -7,7 +7,8 @@
     <%= govuk_error_summary(@form_object) %>
     <%= step_form @form_object, url: nsm_steps_defendant_details_path(@form_object.application, defendant_id: @form_object.record.id) do |f| %>
       <%= f.govuk_fieldset legend: { text: t(@form_object.label_key, index: @form_object.index) }, class: 'moj-add-another__item' do %>
-        <%= f.govuk_text_field :full_name, maxlength_enabled: true %>
+        <%= f.govuk_text_field :first_name, maxlength_enabled: true %>
+        <%= f.govuk_text_field :last_name, maxlength_enabled: true %>
         <% if @form_object.maat_required? %>
           <%= f.govuk_text_field :maat, maxlength_enabled: true %>
         <% end %>

--- a/app/views/prior_authority/steps/client_detail/edit.html.erb
+++ b/app/views/prior_authority/steps/client_detail/edit.html.erb
@@ -8,9 +8,9 @@
     <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
 
     <%= step_form @form_object do |form| %>
-      <%= form.govuk_text_field :client_first_name, label: { text: t(".client_first_name"), size: 'm' } %>
-      <%= form.govuk_text_field :client_last_name, label: { text: t(".client_last_name"), size: 'm' } %>
-      <%= form.govuk_date_field :client_date_of_birth, date_of_birth: true, legend: { text: t(".client_date_of_birth") }, hint: { text: t(".client_date_of_birth_hint") } %>
+      <%= form.govuk_text_field :first_name, label: { text: t(".first_name"), size: 'm' } %>
+      <%= form.govuk_text_field :last_name, label: { text: t(".last_name"), size: 'm' } %>
+      <%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t(".date_of_birth") }, hint: { text: t(".date_of_birth_hint") } %>
 
       <%= form.continue_button %>
     <% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -156,8 +156,10 @@ en:
           attributes: *solicitor_form
         nsm/steps/defendant_details_form:
           attributes:
-            full_name:
-              blank: Full name cannot be blank
+            first_name:
+              blank: First name cannot be blank
+            last_name:
+              blank: Last name cannot be blank
             maat:
               blank: MAAT ID cannot be blank
         nsm/steps/case_details_form:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -57,11 +57,11 @@ en:
               blank: Enter the contact email address
         prior_authority/steps/client_detail_form:
           attributes:
-            client_first_name:
+            first_name:
               blank: Enter the client's first name
-            client_last_name:
+            last_name:
               blank: Enter the client's last name
-            client_date_of_birth:
+            date_of_birth:
               blank: Enter the client's date of birth
               invalid: Enter a valid date
               invalid_day: Enter a valid day

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -206,7 +206,8 @@ en:
         hearing_outcome: Hearing outcome
         matter_type: Matter type
       nsm_steps_defendant_details_form:
-        full_name: Full name
+        first_name: First name
+        last_name: Last name
         maat: MAAT ID
       nsm_steps_reason_for_claim_form:
         reasons_for_claim_options:

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -18,10 +18,10 @@ en:
       client_detail:
         edit:
           caption: 2. About the case
-          client_first_name: First name
-          client_last_name: Last name
-          client_date_of_birth: Date of birth
-          client_date_of_birth_hint: For example, 27 3 2007
+          first_name: First name
+          last_name: Last name
+          date_of_birth: Date of birth
+          date_of_birth_hint: For example, 27 3 2007
           page_title: Client details
       ufn:
         edit:

--- a/db/migrate/20240124143046_add_defendant_to_prior_authority_application.rb
+++ b/db/migrate/20240124143046_add_defendant_to_prior_authority_application.rb
@@ -1,0 +1,24 @@
+class AddDefendantToPriorAuthorityApplication < ActiveRecord::Migration[7.1]
+  def up
+    change_table :defendants, bulk: true do |t|
+      t.uuid :defendable_id
+      t.string :defendable_type
+      t.change :claim_id, :uuid, null: true
+      t.string :first_name
+      t.string :last_name
+      t.date :date_of_birth
+    end
+
+    Defendant.find_each do |d|
+      parts = d.full_name.split(' ', 2)
+      d.update(first_name: parts[0], last_name: parts[1], defendable_type: 'Claim', defendable_id: d.claim_id)
+    end
+
+    change_table :defendants, bulk: true do |t|
+      t.remove :full_name
+      t.remove :claim_id
+      t.change :defendable_id, :uuid, null: false
+      t.change :defendable_type, :string, null: false
+    end
+  end
+end

--- a/db/migrate/20240124153117_remove_client_details_from_prior_authority_application.rb
+++ b/db/migrate/20240124153117_remove_client_details_from_prior_authority_application.rb
@@ -1,0 +1,19 @@
+class RemoveClientDetailsFromPriorAuthorityApplication < ActiveRecord::Migration[7.1]
+  def change
+    PriorAuthorityApplication.find_each do |application|
+      Defendant.create!(
+        defendable_id: application.id,
+        defendable_type: 'PriorAuthorityApplication',
+        first_name: application.client_first_name,
+        last_name: application.client_last_name,
+        date_of_birth: application.client_date_of_birth,
+      )
+    end
+
+    change_table :prior_authority_applications, bulk: true do |t|
+      t.remove :client_date_of_birth
+      t.remove :client_first_name
+      t.remove :client_last_name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_24_143046) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_24_153117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -174,9 +174,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_143046) do
     t.string "ufn"
     t.string "laa_reference"
     t.string "status", default: "pre_draft"
-    t.string "client_first_name"
-    t.string "client_last_name"
-    t.date "client_date_of_birth"
     t.jsonb "navigation_stack", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_11_093801) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_24_143046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -122,14 +122,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_11_093801) do
   end
 
   create_table "defendants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "claim_id", null: false
-    t.string "full_name"
     t.string "maat"
     t.integer "position"
     t.boolean "main", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["claim_id"], name: "index_defendants_on_claim_id"
+    t.uuid "defendable_id", null: false
+    t.string "defendable_type", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.date "date_of_birth"
   end
 
   create_table "disbursements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -243,7 +245,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_11_093801) do
   add_foreign_key "claims", "providers", column: "submitter_id"
   add_foreign_key "claims", "solicitors"
   add_foreign_key "cost_totals", "claims"
-  add_foreign_key "defendants", "claims"
   add_foreign_key "disbursements", "claims"
   add_foreign_key "firm_offices", "firm_offices", column: "previous_id"
   add_foreign_key "prior_authority_applications", "firm_offices"

--- a/spec/factories/defendants.rb
+++ b/spec/factories/defendants.rb
@@ -1,15 +1,16 @@
 FactoryBot.define do
   factory :defendant do
     trait :valid do
-      full_name { 'bobjim' }
+      first_name { 'bob' }
+      last_name { 'jim' }
       maat { 'AA1' }
       position { 1 }
       main { true }
     end
 
     trait :partial do
-      full_name { 'bobjim' }
-      position { 1 }
+      first_name { 'bob' }
+      last_name { 'jim' }
       main { true }
     end
   end

--- a/spec/forms/prior_authority/steps/client_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/client_detail_form_spec.rb
@@ -5,34 +5,34 @@ RSpec.describe PriorAuthority::Steps::ClientDetailForm do
 
   let(:arguments) do
     {
-      application:,
-      client_first_name:,
-      client_last_name:,
-      client_date_of_birth:,
+      record:,
+      first_name:,
+      last_name:,
+      date_of_birth:,
     }
   end
 
   describe '#validate' do
-    let(:application) { instance_double(PriorAuthorityApplication) }
+    let(:record) { instance_double(Defendant) }
 
     context 'with valid client details' do
-      let(:client_first_name) { 'Joe' }
-      let(:client_last_name) { 'Bloggs' }
-      let(:client_date_of_birth) { 20.years.ago.to_date }
+      let(:first_name) { 'Joe' }
+      let(:last_name) { 'Bloggs' }
+      let(:date_of_birth) { 20.years.ago.to_date }
 
       it { is_expected.to be_valid }
     end
 
     context 'with blank client details' do
-      let(:client_first_name) { '' }
-      let(:client_last_name) { '' }
-      let(:client_date_of_birth) { '' }
+      let(:first_name) { '' }
+      let(:last_name) { '' }
+      let(:date_of_birth) { '' }
 
       it 'has a validation errors on the fields' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:client_first_name, :blank)).to be(true)
-        expect(form.errors.of_kind?(:client_last_name, :blank)).to be(true)
-        expect(form.errors.of_kind?(:client_date_of_birth, :blank)).to be(true)
+        expect(form.errors.of_kind?(:first_name, :blank)).to be(true)
+        expect(form.errors.of_kind?(:last_name, :blank)).to be(true)
+        expect(form.errors.of_kind?(:date_of_birth, :blank)).to be(true)
         expect(form.errors.messages.values.flatten)
           .to include("Enter the client's first name",
                       "Enter the client's last name",
@@ -44,44 +44,44 @@ RSpec.describe PriorAuthority::Steps::ClientDetailForm do
   describe '#save' do
     subject(:save) { form.save }
 
-    let(:application) { create(:prior_authority_application) }
+    let(:record) { create(:defendant, defendable: create(:prior_authority_application)) }
 
     context 'with valid client details' do
-      let(:client_first_name) { 'Joe' }
-      let(:client_last_name) { 'Bloggs' }
-      let(:client_date_of_birth) { 20.years.ago.to_date }
+      let(:first_name) { 'Joe' }
+      let(:last_name) { 'Bloggs' }
+      let(:date_of_birth) { 20.years.ago.to_date }
 
       it 'persists the client details' do
-        expect { save }.to change { application.reload.attributes }
+        expect { save }.to change { record.reload.attributes }
           .from(
             hash_including(
-              'client_first_name' => nil,
-              'client_last_name' => nil,
-              'client_date_of_birth' => nil
+              'first_name' => nil,
+              'last_name' => nil,
+              'date_of_birth' => nil
             )
           )
           .to(
             hash_including(
-              'client_first_name' => 'Joe',
-              'client_last_name' => 'Bloggs',
-              'client_date_of_birth' => 20.years.ago.to_date
+              'first_name' => 'Joe',
+              'last_name' => 'Bloggs',
+              'date_of_birth' => 20.years.ago.to_date
             )
           )
       end
     end
 
     context 'with incomplete client details' do
-      let(:client_first_name) { 'Joe' }
-      let(:client_last_name) { '' }
-      let(:client_date_of_birth) { '' }
+      let(:first_name) { 'Joe' }
+      let(:last_name) { '' }
+      let(:date_of_birth) { '' }
 
       it 'does not persist the client details' do
-        expect { save }.not_to change { application.reload.attributes }
+        expect { save }.not_to change { record.reload.attributes }
           .from(
             hash_including(
-              'client_first_name' => nil,
-              'client_last_name' => nil,
-              'client_date_of_birth' => nil
+              'first_name' => nil,
+              'last_name' => nil,
+              'date_of_birth' => nil
             )
           )
       end

--- a/spec/mailers/claim_submission_mailer_spec.rb
+++ b/spec/mailers/claim_submission_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
         ).to include(
           LAA_case_reference: 'LAA-n4AohV',
           UFN: '123456/001',
-          main_defendant_name: 'bobjim',
+          main_defendant_name: 'bob jim',
           defendant_reference: 'MAAT ID: AA1',
           claim_total: '£20.45',
           date: DateTime.now.strftime('%d %B %Y'),
@@ -48,7 +48,7 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
         ).to include(
           LAA_case_reference: 'LAA-n4AohV',
           UFN: '123456/002',
-          main_defendant_name: 'bobjim',
+          main_defendant_name: 'bob jim',
           defendant_reference: "Client's CNTP number: CNTP12345",
           claim_total: '£20.45',
           date: DateTime.now.strftime('%d %B %Y'),

--- a/spec/presenters/prior_authority/tasks/client_detail_spec.rb
+++ b/spec/presenters/prior_authority/tasks/client_detail_spec.rb
@@ -39,5 +39,29 @@ RSpec.describe PriorAuthority::Tasks::ClientDetail, type: :presenter do
     end
   end
 
-  it_behaves_like 'a task with generic complete?', PriorAuthority::Steps::ClientDetailForm
+  describe '#completed?' do
+    context 'when the defendant details are valid' do
+      before do
+        create(:defendant,
+               defendable: application,
+               first_name: 'Jane',
+               last_name: 'Bloggs',
+               date_of_birth: 20.years.ago)
+      end
+
+      it { is_expected.to be_completed }
+    end
+
+    context 'when the defendant details are invalid' do
+      before do
+        create(:defendant,
+               defendable: application,
+               first_name: nil,
+               last_name: 'Bloggs',
+               date_of_birth: 20.years.ago)
+      end
+
+      it { is_expected.not_to be_completed }
+    end
+  end
 end

--- a/spec/services/notify_app_store/message_builder_spec.rb
+++ b/spec/services/notify_app_store/message_builder_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe NotifyAppStore::MessageBuilder do
           'created_at' => '2023-08-17T12:13:14.000Z',
           'defence_statement' => nil,
           'defendants' => [{
-            'full_name' => 'bobjim',
+            'full_name' => 'bob jim',
             'id' => defendant.id,
             'maat' => 'AA1',
             'main' => true,

--- a/spec/steps/nsm/defendants/add/controller_spec.rb
+++ b/spec/steps/nsm/defendants/add/controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Nsm::Steps::DefendantDetailsController, type: :controller do
 
     context 'when defendant_id is passed in' do
       context 'and defendant exists' do
-        let(:defendants) { [Defendant.new(full_name: 'Jim', maat: 'AA1', main: true, position: 1)] }
+        let(:defendants) { [Defendant.new(first_name: 'Jim', last_name: 'S', maat: 'AA1', main: true, position: 1)] }
 
         it 'passes the existing defendant to the form' do
           allow(Nsm::Steps::DefendantDetailsForm).to receive(:build)
@@ -42,7 +42,7 @@ RSpec.describe Nsm::Steps::DefendantDetailsController, type: :controller do
       end
 
       context 'and defendant does not exists' do
-        let(:defendants) { [Defendant.new(full_name: 'Jim', maat: 'AA1', main: true, position: 1)] }
+        let(:defendants) { [Defendant.new(first_name: 'Jim', last_name: 'S', maat: 'AA1', main: true, position: 1)] }
 
         it 'redirect to the summary screen' do
           expect do

--- a/spec/steps/nsm/defendants/add/form_spec.rb
+++ b/spec/steps/nsm/defendants/add/form_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Nsm::Steps::DefendantDetailsForm do
     {
       application:,
       record:,
-      full_name:,
+      first_name:,
+      last_name:,
       maat:,
     }
   end
@@ -16,7 +17,8 @@ RSpec.describe Nsm::Steps::DefendantDetailsForm do
   let(:defendants) { [double(:record), record] }
   let(:record) { double(:record, main:) }
   let(:main) { true }
-  let(:full_name) { 'James' }
+  let(:first_name) { 'James' }
+  let(:last_name) { 'Smith' }
   let(:maat) { 'AA1' }
   let(:claim_type) { ClaimType::NON_STANDARD_MAGISTRATE.to_s }
 
@@ -65,12 +67,21 @@ RSpec.describe Nsm::Steps::DefendantDetailsForm do
   describe '#validations' do
     it { expect(subject).to be_valid }
 
-    context 'when full name is not set' do
-      let(:full_name) { nil }
+    context 'when first name is not set' do
+      let(:first_name) { nil }
 
       it 'has the appropriate error messages' do
         expect(subject).not_to be_valid
-        expect(subject.errors.of_kind?(:full_name, :blank)).to be(true)
+        expect(subject.errors.of_kind?(:first_name, :blank)).to be(true)
+      end
+    end
+
+    context 'when last name is not set' do
+      let(:last_name) { nil }
+
+      it 'has the appropriate error messages' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:last_name, :blank)).to be(true)
       end
     end
 
@@ -94,13 +105,14 @@ RSpec.describe Nsm::Steps::DefendantDetailsForm do
 
   describe '#save' do
     let(:application) { create(:claim) }
-    let(:record) { Defendant.new(claim: application, id: Nsm::StartPage::NEW_RECORD) }
+    let(:record) { Defendant.new(defendable: application, id: Nsm::StartPage::NEW_RECORD) }
 
     context 'when no defendants exist' do
       it 'created with position 1 and main true' do
         expect(subject.save).to be_truthy
         expect(application.defendants.first).to have_attributes(
-          full_name: full_name,
+          first_name: first_name,
+          last_name: last_name,
           maat: maat,
           position: 1,
           main: true
@@ -113,14 +125,15 @@ RSpec.describe Nsm::Steps::DefendantDetailsForm do
 
     context 'when defendants already exist' do
       before do
-        create(:defendant, :valid, claim: application)
+        create(:defendant, :valid, defendable: application)
       end
 
       it 'created with position incremented and main false' do
         expect(subject.save).to be_truthy
         defendant = application.defendants.order(:created_at).last
         expect(defendant).to have_attributes(
-          full_name: full_name,
+          first_name: first_name,
+          last_name: last_name,
           maat: maat,
           position: 2,
           main: false
@@ -132,12 +145,13 @@ RSpec.describe Nsm::Steps::DefendantDetailsForm do
     end
 
     context 'when editing an existing defendnant' do
-      let(:record) { create(:defendant, :valid, claim: application) }
+      let(:record) { create(:defendant, :valid, defendable: application) }
 
       it 'created with position incremented and main false' do
         expect(subject.save).to be_truthy
         expect(record.reload).to have_attributes(
-          full_name: full_name,
+          first_name: first_name,
+          last_name: last_name,
           maat: maat,
           position: 1,
           main: true

--- a/spec/steps/nsm/defendants/integration_spec.rb
+++ b/spec/steps/nsm/defendants/integration_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'User can manage defendants', type: :system do
     visit edit_nsm_steps_defendant_details_path(claim.id, defendant_id: Nsm::StartPage::NEW_RECORD)
 
     within('.govuk-fieldset', text: 'Main defendant') do
-      fill_in 'Full name', with: 'Jim Bob'
+      fill_in 'First name', with: 'Jim'
+      fill_in 'Last name', with: 'Bob'
       fill_in 'MAAT ID', with: 'AA1'
     end
 
@@ -19,7 +20,8 @@ RSpec.describe 'User can manage defendants', type: :system do
 
     expect(claim.reload.defendants).to contain_exactly(
       have_attributes(
-        full_name: 'Jim Bob',
+        first_name: 'Jim',
+        last_name: 'Bob',
         maat: 'AA1',
         position: 1,
         main: true,
@@ -28,7 +30,7 @@ RSpec.describe 'User can manage defendants', type: :system do
   end
 
   it 'can add an additional defendant' do
-    claim.defendants.create(full_name: 'Jim Bob', maat: 'AA1', position: 1, main: true)
+    claim.defendants.create(first_name: 'Jim', last_name: 'Bob', maat: 'AA1', position: 1, main: true)
 
     visit edit_nsm_steps_defendant_summary_path(claim.id)
     choose 'Yes'
@@ -36,7 +38,8 @@ RSpec.describe 'User can manage defendants', type: :system do
     click_on 'Save and continue'
 
     within('.govuk-fieldset', text: 'Additional defendant') do
-      fill_in 'Full name', with: 'Bob Jim'
+      fill_in 'First name', with: 'Bob'
+      fill_in 'Last name', with: 'Jim'
       fill_in 'MAAT ID', with: 'BB1'
     end
 
@@ -44,13 +47,15 @@ RSpec.describe 'User can manage defendants', type: :system do
 
     expect(claim.reload.defendants).to contain_exactly(
       have_attributes(
-        full_name: 'Jim Bob',
+        first_name: 'Jim',
+        last_name: 'Bob',
         maat: 'AA1',
         position: 1,
         main: true,
       ),
       have_attributes(
-        full_name: 'Bob Jim',
+        first_name: 'Bob',
+        last_name: 'Jim',
         maat: 'BB1',
         position: 2,
         main: false,
@@ -59,8 +64,8 @@ RSpec.describe 'User can manage defendants', type: :system do
   end
 
   it 'can delete a defendant' do
-    claim.defendants.create(full_name: 'Jim Bob', maat: 'AA1', position: 1, main: true)
-    claim.defendants.create(full_name: 'Bob Jim', maat: 'BB1', position: 2, main: false)
+    claim.defendants.create(first_name: 'Jim', last_name: 'Bob', maat: 'AA1', position: 1, main: true)
+    claim.defendants.create(first_name: 'Bob', last_name: 'Jim', maat: 'BB1', position: 2, main: false)
 
     visit edit_nsm_steps_defendant_summary_path(claim.id)
 
@@ -70,7 +75,8 @@ RSpec.describe 'User can manage defendants', type: :system do
 
     expect(claim.reload.defendants).to contain_exactly(
       have_attributes(
-        full_name: 'Jim Bob',
+        first_name: 'Jim',
+        last_name: 'Bob',
         maat: 'AA1',
         position: 1,
         main: true,

--- a/spec/steps/nsm/defendants/presenter_spec.rb
+++ b/spec/steps/nsm/defendants/presenter_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Nsm::Tasks::Defendants, type: :system do
     end
 
     context 'when defendants exist' do
-      let(:defendants) { [Defendant.new(full_name: 'Jim Bob')] }
+      let(:defendants) { [Defendant.new(first_name: 'Jim', last_name: 'Bob')] }
       let(:defendant_form) { double(:defendant_form, valid?: valid) }
 
       before do


### PR DESCRIPTION
## Description of change
Made `defendants` table polymorphic
Replaced full_name with first_name and last_name and amended NSM flow to use two fields
Updated PriorAuthority to use a defendants object rather than store client details on the main record

## Link to relevant ticket
https://dsdmoj.atlassian.net/browse/CRM457-957

## Notes for reviewer
To keep compatibility, the message builder is sending defendant full name to the app store as a single field. If we want to change that we'll need to update the caseworker app to cope with two separate fields

