### PR TITLE
CRM457-1015: Give priority to text field rather than hidden select

### DIFF
--- a/app/forms/prior_authority/steps/primary_quote_form.rb
+++ b/app/forms/prior_authority/steps/primary_quote_form.rb
@@ -13,8 +13,8 @@ module PriorAuthority
       validates :postcode, presence: true, uk_postcode: true
 
       def service_type_suggestion=(value)
-        if value.in?(translated_values)
-          self.service_type = service_type.value
+        if value.in?(translations.keys)
+          self.service_type = translations[value]
           self.custom_service_name = nil
         else
           self.service_type = 'custom' if value.present?
@@ -34,8 +34,8 @@ module PriorAuthority
         }
       end
 
-      def translated_values
-        QuoteServices.values.map(&:translated)
+      def translations
+        QuoteServices.values.to_h { [_1.translated, _1.value] }
       end
     end
   end

--- a/app/forms/prior_authority/steps/primary_quote_form.rb
+++ b/app/forms/prior_authority/steps/primary_quote_form.rb
@@ -13,6 +13,13 @@ module PriorAuthority
       validates :postcode, presence: true, uk_postcode: true
 
       def service_type_suggestion=(value)
+        # The value of service_type_suggestion is the contents of the visible text field, which is the translated value.
+        # This is separate from the value of service_type which is the untranslated value, stored in a hidden dropdown.
+        # The complication is that if a user types in a value to the text field but doesn't click the autocomplete,
+        # service_type_suggestion will contain an accurate translated value, but service_type dropdown contains
+        # a false untranslated value.
+        # So to avoid being caught out, the translated value needs to take precedence, and we need to infer the
+        # untranslated value from that.
         if value.in?(translations.keys)
           self.service_type = translations[value]
           self.custom_service_name = nil

--- a/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
+++ b/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
@@ -120,12 +120,20 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
   describe '#service_type' do
     subject(:form) { described_class.new(arguments.merge(service_type_suggestion:)) }
 
-    let(:service_type) { PriorAuthority::QuoteServices.values.sample }
+    let(:service_type) { 'culture_expert' }
 
-    context 'service type suggestion matches a quote service' do
-      let(:service_type_suggestion) { service_type.translated }
+    context 'service type suggestion matches provided service' do
+      let(:service_type_suggestion) { 'Culture expert' }
 
-      it { expect(subject.service_type).to eq(service_type) }
+      it { expect(subject.service_type).to eq(PriorAuthority::QuoteServices::CULTURE_EXPERT) }
+    end
+
+    context 'service type suggestion matches a different service' do
+      let(:service_type_suggestion) { 'Computer Experts' }
+
+      it 'uses the service type associated with the suggestion' do
+        expect(subject.service_type).to eq(PriorAuthority::QuoteServices::COMPUTER_EXPERTS)
+      end
     end
 
     context 'service type suggestion does not match a quote service' do


### PR DESCRIPTION
## Description of change
The bug was that if you type a value into the service cost but don't click on a pre-selected option, the hidden field value doesn't update, and we were giving priority to the hidden field over the text field. Fixing this means that users aren't forced to click for a change to 'take'

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1015)


