### PR TITLE
CRM457-975: Contact detail onwards navigation

### DIFF
--- a/app/controllers/prior_authority/steps/base_controller.rb
+++ b/app/controllers/prior_authority/steps/base_controller.rb
@@ -10,7 +10,7 @@ module PriorAuthority
       end
 
       def after_commit_redirect_path
-        prior_authority_after_commit_path(id: current_application.id)
+        prior_authority_root_path(anchor: 'drafts')
       end
 
       # :nocov:

--- a/app/services/decisions/decision_tree.rb
+++ b/app/services/decisions/decision_tree.rb
@@ -89,7 +89,7 @@ module Decisions
     # ---------------------------------
     # prior authority application steps
     # ---------------------------------
-    from(:case_contact).goto(edit: 'prior_authority/steps/client_detail')
+    from(:case_contact).goto(show: 'prior_authority/steps/start_page')
     from(:client_detail)
       .when(-> { application.prison_law? })
       .goto(edit: 'prior_authority/steps/next_hearing')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,8 +117,6 @@ Rails.application.routes.draw do
     resources :service_types, only: [:index], format: :js
 
     scope 'applications/:id' do
-      get '/steps/start_page', to: 'steps/start_page#show', as: 'after_commit'
-
       namespace :steps do
         edit_step :prison_law
         edit_step :authority_value

--- a/spec/system/prior_authority/case_contact_spec.rb
+++ b/spec/system/prior_authority/case_contact_spec.rb
@@ -13,13 +13,9 @@ RSpec.describe 'Prior authority applications - add case contact' do
     fill_in 'Email address', with: 'john@does.com'
     fill_in 'Firm name', with: 'LegalCorp Ltd'
     fill_in 'Firm account number', with: 'A12345'
-    click_on 'Save and come back later'
+    click_on 'Save and continue'
 
     expect(page).to have_content 'Case contactCompleted'
-
-    click_on 'Case contact'
-    click_on 'Save and continue'
-    expect(page).to have_title 'Client details'
   end
 
   it 'does validations' do
@@ -37,6 +33,28 @@ RSpec.describe 'Prior authority applications - add case contact' do
     click_on 'Case contact'
     click_on 'Save and come back later'
 
-    expect(page).to have_content 'Case contactIn progress'
+    expect(page).to have_title 'Your applications'
+  end
+
+  context 'when the screen has already been filled in' do
+    before do
+      fill_in_case_contact
+    end
+
+    it 'allows contact detail updating' do
+      click_on 'Case contact'
+      fill_in 'Full name', with: 'Jane Doe'
+      click_on 'Save and continue'
+
+      expect(page).to have_content 'Case contactCompleted'
+    end
+
+    it 'allows firm detail updating' do
+      click_on 'Case contact'
+      fill_in 'Firm account number', with: 'A12345'
+      click_on 'Save and continue'
+
+      expect(page).to have_content 'Case contactCompleted'
+    end
   end
 end

--- a/spec/system/prior_authority/case_detail_spec.rb
+++ b/spec/system/prior_authority/case_detail_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe 'Prior authority applications - add case details' do
       choose 'Yes'
     end
 
-    click_on 'Save and come back later'
-    expect(page).to have_content 'Case and hearing detailsIn progress'
+    click_on 'Save and continue'
+    expect(page).to have_content 'Hearing details'
   end
 
   it 'validates client detail fields' do
@@ -55,6 +55,6 @@ RSpec.describe 'Prior authority applications - add case details' do
     click_on 'Case and hearing details'
 
     click_on 'Save and come back later'
-    expect(page).to have_content 'Case and hearing detailsIn progress'
+    expect(page).to have_content 'Your applications'
   end
 end

--- a/spec/system/prior_authority/client_detail_spec.rb
+++ b/spec/system/prior_authority/client_detail_spec.rb
@@ -18,12 +18,9 @@ RSpec.describe 'Prior authority applications - add client details' do
       fill_in 'Year', with: '2000'
     end
 
-    click_on 'Save and come back later'
-
-    expect(page).to have_content 'Client detailsCompleted'
-
-    click_on 'Client details'
     click_on 'Save and continue'
+
+    expect(page).to have_content 'Case details'
   end
 
   it 'validates client detail fields' do
@@ -41,6 +38,6 @@ RSpec.describe 'Prior authority applications - add client details' do
     click_on 'Client details'
 
     click_on 'Save and come back later'
-    expect(page).to have_content 'Client detailsIn progress'
+    expect(page).to have_content 'Your applications'
   end
 end

--- a/spec/system/prior_authority/hearing_details_spec.rb
+++ b/spec/system/prior_authority/hearing_details_spec.rb
@@ -72,6 +72,6 @@ RSpec.describe 'Prior authority applications - add hearing details' do
 
   it 'allows save and come back later' do
     click_on 'Save and come back later'
-    expect(page).to have_content('Case and hearing detailsIn progress')
+    expect(page).to have_content('Your applications')
   end
 end

--- a/spec/system/prior_authority/next_hearing_spec.rb
+++ b/spec/system/prior_authority/next_hearing_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'Prior authority applications (prison law) - add next hearing' do
   context 'when navigation from previous step' do
     before do
       fill_in_until_step(:your_application_progress, prison_law: 'Yes')
-      click_on 'Client details'
       fill_in_client_detail
     end
 

--- a/spec/system/prior_authority/primary_quote_spec.rb
+++ b/spec/system/prior_authority/primary_quote_spec.rb
@@ -40,6 +40,6 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
     click_on 'Primary quote'
 
     click_on 'Save and come back later'
-    expect(page).to have_content 'Primary quote In progress'
+    expect(page).to have_content 'Your applications'
   end
 end

--- a/spec/system/support/prior_authority/step_helpers.rb
+++ b/spec/system/support/prior_authority/step_helpers.rb
@@ -64,6 +64,7 @@ module PriorAuthority
     end
 
     def fill_in_client_detail
+      click_on 'Client details'
       fill_in 'First name', with: 'John'
       fill_in 'Last name', with: 'Doe'
 


### PR DESCRIPTION
## Description of change
From QA:
- 'Save and come back later' should redirect to 'Your applications', not 'Your application progress' - this is a universal update
- 'Save and continue' from 'case contact' should redirect to 'Your application progress', not 'Client details'

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-975)

