### PR TITLE
CRM457-1040: Fix bug in navigation stack logic

### DIFF
--- a/app/controllers/prior_authority/steps/base_controller.rb
+++ b/app/controllers/prior_authority/steps/base_controller.rb
@@ -22,6 +22,10 @@ module PriorAuthority
       def service
         Providers::Gatekeeper::PAA
       end
+
+      # The default behaviour of prune_navigation_stack assumes linear completion of tasks
+      # which doesn't apply to Prior Authority
+      def prune_navigation_stack; end
     end
   end
 end

--- a/app/controllers/prior_authority/steps/base_controller.rb
+++ b/app/controllers/prior_authority/steps/base_controller.rb
@@ -23,9 +23,10 @@ module PriorAuthority
         Providers::Gatekeeper::PAA
       end
 
-      # The default behaviour of prune_navigation_stack assumes linear completion of tasks
-      # which doesn't apply to Prior Authority
-      def prune_navigation_stack; end
+      def prune_navigation_stack
+        # The default behaviour of prune_navigation_stack assumes linear completion of tasks
+        # which doesn't apply to Prior Authority. So we do a noop instead.
+      end
     end
   end
 end

--- a/spec/system/prior_authority/task_list_spec.rb
+++ b/spec/system/prior_authority/task_list_spec.rb
@@ -1,0 +1,16 @@
+require 'system_helper'
+
+RSpec.describe 'Prior authority applications - task list' do
+  before do
+    fill_in_until_step(:primary_quote, prison_law: 'Yes')
+  end
+
+  it 'allows me to go back to a previous step without invalidating subsequent steps' do
+    expect(page).to have_content 'Client detailsCompleted'
+    expect(page).to have_content 'Case and hearing detailsCompleted'
+    click_on 'Client details'
+    fill_in_client_detail
+    expect(page).to have_content 'Client detailsCompleted'
+    expect(page).to have_content 'Case and hearing detailsCompleted'
+  end
+end

--- a/spec/system/support/prior_authority/step_helpers.rb
+++ b/spec/system/support/prior_authority/step_helpers.rb
@@ -26,15 +26,19 @@ module PriorAuthority
       return if step == :case_detail
 
       click_on 'Case and hearing details'
-      fill_in_case_detail
+      if prison_law == 'Yes'
+        fill_in_next_hearing
+      else
+        fill_in_case_detail
 
-      return if step == :hearing_detail
+        return if step == :hearing_detail
 
-      fill_in_hearing_detail(court_type:)
+        fill_in_hearing_detail(court_type:)
 
-      return if step.in?(%i[psychiatric_liaison youth_court])
+        return if step.in?(%i[psychiatric_liaison youth_court])
 
-      fill_in_youth_court
+        fill_in_youth_court
+      end
 
       return if step == :primary_quote
 
@@ -108,6 +112,11 @@ module PriorAuthority
         choose 'Yes'
       end
 
+      click_on 'Save and continue'
+    end
+
+    def fill_in_next_hearing
+      choose 'No'
       click_on 'Save and continue'
     end
 


### PR DESCRIPTION
## Description of change

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1040)

## Notes for reviewer
Previously if you completed steps A and B then went back and edited step A, step B would be marked as 'not started'. Which would be extra problematic if step B came before step A in the task list.

As we have our own logic for determining where changes in A invalidate step B, the simplest thing is to simply remove the 'prune' mechanism that's causing the app to forget about previous interactions.
