### PR TITLE
Add shared date and time formats and use

### DIFF
--- a/app/mailers/claim_submission_mailer.rb
+++ b/app/mailers/claim_submission_mailer.rb
@@ -66,7 +66,7 @@ class ClaimSubmissionMailer < GovukNotifyRails::Mailer
   end
 
   def submission_date
-    DateTime.now.strftime('%d %B %Y')
+    DateTime.now.to_fs(:stamp)
   end
 
   def feedback_url

--- a/app/presenters/nsm/check_answers/application_status_card.rb
+++ b/app/presenters/nsm/check_answers/application_status_card.rb
@@ -27,7 +27,7 @@ module Nsm
       def date_actioned_row
         {
           head_key: date_actioned_head,
-          text: claim.updated_at&.strftime('%d %B %Y')
+          text: claim.updated_at&.to_fs(:stamp)
         }
       end
 

--- a/app/presenters/nsm/check_answers/case_details_card.rb
+++ b/app/presenters/nsm/check_answers/case_details_card.rb
@@ -22,7 +22,7 @@ module Nsm
           {
             head_key: 'main_offence_date',
             text: check_missing(claim.main_offence_date) do
-                    claim.main_offence_date.strftime('%d %B %Y')
+                    claim.main_offence_date.to_fs(:stamp)
                   end
           },
           {
@@ -47,7 +47,7 @@ module Nsm
                                 value_field: claim.remitted_to_magistrate_date,
                                 boolean_key: 'remitted_to_magistrate',
                                 value_key: 'remitted_to_magistrate_date') do
-            claim.remitted_to_magistrate_date.strftime('%d %B %Y')
+            claim.remitted_to_magistrate_date.to_fs(:stamp)
           end
         ].flatten
       end

--- a/app/presenters/nsm/check_answers/case_disposal_card.rb
+++ b/app/presenters/nsm/check_answers/case_disposal_card.rb
@@ -38,7 +38,7 @@ module Nsm
 
         array << {
           head_key: head_key,
-          text: date_value.strftime('%d %B %Y')
+          text: date_value.to_fs(:stamp)
         }
       end
     end

--- a/app/presenters/nsm/check_answers/claim_details_card.rb
+++ b/app/presenters/nsm/check_answers/claim_details_card.rb
@@ -38,11 +38,11 @@ module Nsm
           end,
           process_boolean_value(boolean_field: claim.work_before, value_field: claim.work_before_date,
                                 boolean_key: 'work_before', value_key: 'work_before_date') do
-            claim.work_before_date.strftime('%d %B %Y')
+            claim.work_before_date.to_fs(:stamp)
           end,
           process_boolean_value(boolean_field: claim.work_after, value_field: claim.work_after_date,
                                 boolean_key: 'work_after', value_key: 'work_after_date') do
-            claim.work_after_date.strftime('%d %B %Y')
+            claim.work_after_date.to_fs(:stamp)
           end
         ].flatten
       end

--- a/app/presenters/nsm/check_answers/claim_justification_card.rb
+++ b/app/presenters/nsm/check_answers/claim_justification_card.rb
@@ -38,7 +38,7 @@ module Nsm
           additional_fields << {
             head_key: 'representation_order_withdrawn_date',
             text: check_missing(claim.representation_order_withdrawn_date) do
-              claim.representation_order_withdrawn_date.strftime('%d %B %Y')
+              claim.representation_order_withdrawn_date.to_fs(:stamp)
             end
           }
         end

--- a/app/presenters/nsm/check_answers/claim_type_card.rb
+++ b/app/presenters/nsm/check_answers/claim_type_card.rb
@@ -34,7 +34,7 @@ module Nsm
         [
           {
             head_key: 'rep_order_date',
-            text: claim.rep_order_date.try(:strftime, '%d %B %Y')
+            text: claim.rep_order_date&.to_fs(:stamp)
           }
         ]
       end
@@ -47,7 +47,7 @@ module Nsm
           },
           {
             head_key: 'cntp_rep_order',
-            text: claim.cntp_date.try(:strftime, '%d %B %Y')
+            text: claim.cntp_date&.to_fs(:stamp)
           }
         ]
       end

--- a/app/presenters/nsm/check_answers/hearing_details_card.rb
+++ b/app/presenters/nsm/check_answers/hearing_details_card.rb
@@ -17,7 +17,7 @@ module Nsm
           {
             head_key: 'hearing_date',
             text: check_missing(hearing_details_form.first_hearing_date) do
-              hearing_details_form.first_hearing_date.strftime('%d %B %Y')
+              hearing_details_form.first_hearing_date.to_fs(:stamp)
             end
           },
           {

--- a/app/views/nsm/claims/index.html.erb
+++ b/app/views/nsm/claims/index.html.erb
@@ -87,7 +87,7 @@
               <% end %>
             </td>
             <td class="govuk-table__cell"><%= check_missing(claim.main_defendant&.full_name) %></td>
-            <td class="govuk-table__cell"><%= claim.updated_at.strftime('%d %B %Y') %></td>
+            <td class="govuk-table__cell"><%= claim.updated_at.to_fs(:stamp) %></td>
             <td class="govuk-table__cell"><%= claim.laa_reference %></td>
             <td class="govuk-table__cell">
               <strong class="govuk-tag <%= t(".status_colour.#{claim.status}") %>">

--- a/app/views/prior_authority/applications/frame_contents/_assessed.html.erb
+++ b/app/views/prior_authority/applications/frame_contents/_assessed.html.erb
@@ -21,7 +21,7 @@
             <%= application.defendant&.full_name %>
           </td>
           <td class="govuk-table__cell">
-            <%= application.updated_at.strftime('%d %B %Y') %>
+            <%= application.updated_at.to_fs(:stamp) %>
           </td>
           <td class="govuk-table__cell">
             <%= application.laa_reference %>

--- a/app/views/prior_authority/applications/frame_contents/_draft.html.erb
+++ b/app/views/prior_authority/applications/frame_contents/_draft.html.erb
@@ -24,7 +24,7 @@
             <%= application.defendant&.full_name %>
           </td>
           <td class="govuk-table__cell">
-            <%= application.updated_at.strftime('%d %B %Y') %>
+            <%= application.updated_at.to_fs(:stamp) %>
           </td>
           <td class="govuk-table__cell">
             <%= application.laa_reference %>

--- a/app/views/prior_authority/applications/frame_contents/_submitted.html.erb
+++ b/app/views/prior_authority/applications/frame_contents/_submitted.html.erb
@@ -21,7 +21,7 @@
             <%= application.defendant&.full_name %>
           </td>
           <td class="govuk-table__cell">
-            <%= application.updated_at.strftime('%d %B %Y') %>
+            <%= application.updated_at.to_fs(:stamp) %>
           </td>
           <td class="govuk-table__cell">
             <%= application.laa_reference %>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,7 @@
+# Add consistent default time formats for use by presentation layer
+# `my_date.to_fs(:stamp)`
+# instead of
+# `my_date.strftime('%d %B %Y')`
+#
+Date::DATE_FORMATS[:stamp] = '%d %B %Y' # DD MONTH YYYY
+Time::DATE_FORMATS[:stamp] = '%d %B %Y' # DD MONTH YYYY

--- a/spec/mailers/claim_submission_mailer_spec.rb
+++ b/spec/mailers/claim_submission_mailer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
           main_defendant_name: 'bob jim',
           defendant_reference: 'MAAT ID: AA1',
           claim_total: '£20.45',
-          date: DateTime.now.strftime('%d %B %Y'),
+          date: DateTime.now.to_fs(:stamp),
           feedback_url: 'tbc'
         )
       end
@@ -51,7 +51,7 @@ RSpec.describe ClaimSubmissionMailer, type: :mailer do
           main_defendant_name: 'bob jim',
           defendant_reference: "Client's CNTP number: CNTP12345",
           claim_total: '£20.45',
-          date: DateTime.now.strftime('%d %B %Y'),
+          date: DateTime.now.to_fs(:stamp),
           feedback_url: 'tbc'
         )
       end

--- a/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
   end
 
   describe '#row_data' do
-    context 'non standard magistrates claim' do
+    context 'with non standard magistrates claim' do
       let(:claim) { build(:claim, :case_type_magistrates) }
 
       it 'generates magistrates rows' do
@@ -37,7 +37,16 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
       end
     end
 
-    context 'breach of injunction claim' do
+    context 'with non standard magistrates claim without rep order date' do
+      let(:claim) { build(:claim, :case_type_magistrates, rep_order_date: nil) }
+
+      it 'allows a nil rep order date' do
+        expect(subject.row_data)
+          .to match(a_hash_including(head_key: 'rep_order_date', text: nil))
+      end
+    end
+
+    context 'with breach of injunction claim' do
       let(:claim) { build(:claim, :case_type_breach) }
 
       it 'generates magistrates rows' do
@@ -62,6 +71,15 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             }
           ]
         )
+      end
+    end
+
+    context 'with breach of injunction claim without contempt date' do
+      let(:claim) { build(:claim, :case_type_breach, cntp_date: nil) }
+
+      it 'allows a nil contempt date' do
+        expect(subject.row_data)
+          .to match(a_hash_including(head_key: 'cntp_rep_order', text: nil))
       end
     end
   end


### PR DESCRIPTION
## Description of change
Add shared date and time formats and use

 [came out of ](https://dsdmoj.atlassian.net/browse/CRM457-979)

There are multiple locations where the date format
`'%d %B %Y'` is used. Adding and using a shared format
date/time  stamp is something rails provides and can help to ensure
consistency, as well as the potential for simple amendment.

```rb
\# instead of
my_date.strftime('%d %B %Y')
\# use
my_date.to_fs(:stamp)
```

## Notes for reviewer
This has only be used to apply the format in the multiple
places that the `'%d %B %Y'` date/time format is already used. 

There are no performance benefits to my knowledge, just consistency.
