### PR TITLE
crm457-979: namespace tasklist section headers

### DIFF
--- a/app/presenters/nsm/start_page.rb
+++ b/app/presenters/nsm/start_page.rb
@@ -5,25 +5,50 @@ module Nsm
     NEW_RECORD = '00000000-0000-0000-0000-000000000000'.freeze
 
     class PreTaskList < TaskList::Collection
-      SECTIONS = [[:what, [->(app) { "nsm/claim_type.#{app.claim_type}" }]]].freeze
+      SECTIONS = [['nsm/what', [->(app) { "nsm/claim_type.#{app.claim_type}" }]]].freeze
     end
 
     class TaskList < TaskList::Collection
       SECTIONS = [
-        [:about_you, ['nsm/firm_details']],
-        [:defendant, ['nsm/defendants',]],
-        [:case, ['nsm/case_details', 'nsm/hearing_details', 'nsm/case_disposal']],
-        [:claim,
-         ['nsm/reason_for_claim',
-          'nsm/claim_details',
-          'nsm/work_items',
-          'nsm/letters_calls',
-          'nsm/disbursements',
-          'nsm/cost_summary',
-          'nsm/other_info']],
-        [:evidence, ['nsm/supporting_evidence']],
-        [:review,
-         ['nsm/check_answers', 'nsm/solicitor_declaration']],
+        [
+          'nsm/about_you', [
+            'nsm/firm_details'
+          ]
+        ],
+        [
+          'nsm/defendant', [
+            'nsm/defendants',
+          ]
+        ],
+        [
+          'nsm/case', [
+            'nsm/case_details',
+            'nsm/hearing_details',
+            'nsm/case_disposal'
+          ]
+        ],
+        [
+          'nsm/claim', [
+            'nsm/reason_for_claim',
+            'nsm/claim_details',
+            'nsm/work_items',
+            'nsm/letters_calls',
+            'nsm/disbursements',
+            'nsm/cost_summary',
+            'nsm/other_info'
+          ]
+        ],
+        [
+          'nsm/evidence', [
+            'nsm/supporting_evidence'
+          ]
+        ],
+        [
+          'nsm/review', [
+            'nsm/check_answers',
+            'nsm/solicitor_declaration'
+          ]
+        ],
       ].freeze
     end
   end

--- a/app/presenters/prior_authority/start_page.rb
+++ b/app/presenters/prior_authority/start_page.rb
@@ -2,25 +2,29 @@ module PriorAuthority
   module StartPage
     class PreTaskList < TaskList::Collection
       SECTIONS = [
-        [:application_detail, ['prior_authority/ufn']],
+        [
+          'prior_authority/application_detail', [
+            'prior_authority/ufn'
+          ]
+        ],
       ].freeze
     end
 
     class TaskList < TaskList::Collection
       SECTIONS = [
         [
-          :contact_details, [
+          'prior_authority/contact_details', [
             'prior_authority/case_contact'
           ],
         ],
         [
-          :about_case, [
+          'prior_authority/about_case', [
             'prior_authority/client_detail',
             'prior_authority/case_and_hearing_detail',
           ],
         ],
         [
-          :about_request, [
+          'prior_authority/about_request', [
             'prior_authority/primary_quote',
             'prior_authority/reason_why'
           ],

--- a/config/locales/en/tasklist.yml
+++ b/config/locales/en/tasklist.yml
@@ -2,19 +2,18 @@
 en:
   tasklist:
     heading:
-      application_detail: Application details
-      about_case: About the case
-      contact_details: Contact details
-      about_request: About the request
-      case_contact: Case contact
-      what: What you are claiming
-      about_you: About you
-      case: About the case
-      defendant: About the defendant
-      claim: About the claim
-      evidence: Supporting evidence
-      review: Review and confirm
-      about_request: About the request
+      nsm/what: What you are claiming
+      nsm/about_you: About you
+      nsm/case: About the case
+      nsm/defendant: About the defendant
+      nsm/claim: About the claim
+      nsm/evidence: Supporting evidence
+      nsm/review: Review and confirm
+      prior_authority/application_detail: Application details
+      prior_authority/about_case: About the case
+      prior_authority/about_request: About the request
+      prior_authority/contact_details: Contact details
+      prior_authority/review: Apply
     task:
       prior_authority/ufn: Unique file number
       prior_authority/case_contact: Case contact
@@ -22,6 +21,7 @@ en:
       prior_authority/client_detail: Client details
       prior_authority/primary_quote: Primary quote
       prior_authority/reason_why: Reason for prior authority
+      prior_authority/check_answers: Submit application
       nsm/claim_type:
         non_standard_magistrate: Non-standard magistrates’ court payment
         breach_of_injunction: Breach of injunction court payment


### PR DESCRIPTION
## Description of change
Namespace tasklist section headers

 [Came out of ticket](https://dsdmoj.atlassian.net/browse/CRM457-979)

To provide consistency with prior authority and,specifically, namespaced translation lookup for NSM
and PA applications and allow use of the same header
sub-key if desired.

