### PR TITLE
CRM457-1106: Alternative quote costs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-alpine3.18 AS base
+FROM ruby:3.2.2-alpine3.19 AS base
 LABEL maintainer="Non-standard magistrates' court payment team"
 
 # temp fix to security issue in base image: ruby:3.2.2-alpine3.18

--- a/app/controllers/concerns/add_another_methods.rb
+++ b/app/controllers/concerns/add_another_methods.rb
@@ -43,6 +43,10 @@ module AddAnotherMethods
     @record = object_collection.find(params[:id])
   end
 
+  def reload
+    render :edit
+  end
+
   # :nocov:
   def build_form_object
     raise 'Implement in subclass'

--- a/app/controllers/prior_authority/steps/additional_cost_details_controller.rb
+++ b/app/controllers/prior_authority/steps/additional_cost_details_controller.rb
@@ -23,10 +23,6 @@ module PriorAuthority
       def as
         :additional_cost_details
       end
-
-      def redirect_to_current_object
-        redirect_to edit_prior_authority_steps_additional_cost_detail_path(current_application, record)
-      end
     end
   end
 end

--- a/app/controllers/prior_authority/steps/delete_travel_controller.rb
+++ b/app/controllers/prior_authority/steps/delete_travel_controller.rb
@@ -3,15 +3,20 @@ module PriorAuthority
     class DeleteTravelController < BaseController
       def edit
         @form_object = DeleteTravelForm.build(
-          current_application
+          record,
+          application: current_application
         )
       end
 
       def update
-        update_and_advance(DeleteTravelForm, as:, after_commit_redirect_path:)
+        update_and_advance(DeleteTravelForm, as:, after_commit_redirect_path:, record:)
       end
 
       private
+
+      def record
+        current_application.primary_quote
+      end
 
       def as
         :delete_travel

--- a/app/controllers/prior_authority/steps/primary_quote_controller.rb
+++ b/app/controllers/prior_authority/steps/primary_quote_controller.rb
@@ -1,8 +1,6 @@
 module PriorAuthority
   module Steps
     class PrimaryQuoteController < BaseController
-      before_action :set_service_type
-
       def edit
         @form_object = PrimaryQuoteForm.build(
           record,
@@ -26,14 +24,6 @@ module PriorAuthority
 
       def additional_permitted_params
         %i[service_type_suggestion service_type custom_service_name]
-      end
-
-      def set_service_type
-        return unless current_application.service_type == 'custom'
-
-        # This ensures that the 'service type suggestion' field in the UI is
-        # is pre-populated with the custom name
-        current_application.service_type = current_application.custom_service_name
       end
     end
   end

--- a/app/controllers/prior_authority/steps/primary_quote_controller.rb
+++ b/app/controllers/prior_authority/steps/primary_quote_controller.rb
@@ -1,24 +1,23 @@
 module PriorAuthority
   module Steps
     class PrimaryQuoteController < BaseController
+      before_action :set_service_type
+
       def edit
         @form_object = PrimaryQuoteForm.build(
-          primary_quote,
+          record,
           application: current_application
         )
       end
 
       def update
-        record = primary_quote
         update_and_advance(PrimaryQuoteForm, as:, after_commit_redirect_path:, record:)
       end
 
       private
 
-      def primary_quote
-        record = current_application.primary_quote || current_application.build_primary_quote
-        record.service_type = record.custom_service_name if record.service_type == 'custom'
-        record
+      def record
+        current_application.primary_quote || current_application.build_primary_quote
       end
 
       def as
@@ -26,7 +25,13 @@ module PriorAuthority
       end
 
       def additional_permitted_params
-        [:service_type_suggestion]
+        %i[service_type_suggestion service_type custom_service_name]
+      end
+
+      def set_service_type
+        return unless current_application.service_type == 'custom'
+
+        current_application.service_type = current_application.custom_service_name
       end
     end
   end

--- a/app/controllers/prior_authority/steps/primary_quote_controller.rb
+++ b/app/controllers/prior_authority/steps/primary_quote_controller.rb
@@ -31,6 +31,8 @@ module PriorAuthority
       def set_service_type
         return unless current_application.service_type == 'custom'
 
+        # This ensures that the 'service type suggestion' field in the UI is
+        # is pre-populated with the custom name
         current_application.service_type = current_application.custom_service_name
       end
     end

--- a/app/controllers/prior_authority/steps/travel_detail_controller.rb
+++ b/app/controllers/prior_authority/steps/travel_detail_controller.rb
@@ -3,15 +3,20 @@ module PriorAuthority
     class TravelDetailController < BaseController
       def edit
         @form_object = TravelDetailForm.build(
-          current_application
+          record,
+          application: current_application
         )
       end
 
       def update
-        update_and_advance(TravelDetailForm, as:, after_commit_redirect_path:)
+        update_and_advance(TravelDetailForm, as:, after_commit_redirect_path:, record:)
       end
 
       private
+
+      def record
+        current_application.primary_quote
+      end
 
       def as
         :travel_detail

--- a/app/forms/prior_authority/quote_cost_validations.rb
+++ b/app/forms/prior_authority/quote_cost_validations.rb
@@ -9,11 +9,15 @@ module PriorAuthority
                 inclusion: { in: PriorAuthority::Steps::QuoteCostForm::COST_TYPES, allow_nil: false },
                 if: :variable_cost_type?
 
-      validates :items, presence: true, numericality: { greater_than: 0 }, if: :per_item?
-      validates :cost_per_item, presence: true, numericality: { greater_than: 0 }, if: :per_item?
+      with_options if: :per_item? do
+        validates :items, presence: true, numericality: { greater_than: 0 }
+        validates :cost_per_item, presence: true, numericality: { greater_than: 0 }
+      end
 
-      validates :period, presence: true, time_period: true, if: :per_hour?
-      validates :cost_per_hour, presence: true, numericality: { greater_than: 0 }, if: :per_hour?
+      with_options if: :per_hour? do
+        validates :period, presence: true, time_period: true
+        validates :cost_per_hour, presence: true, numericality: { greater_than: 0 }
+      end
     end
   end
 end

--- a/app/forms/prior_authority/quote_cost_validations.rb
+++ b/app/forms/prior_authority/quote_cost_validations.rb
@@ -1,0 +1,19 @@
+module PriorAuthority
+  # We have these as a module rather than including in QuoteCostForm because the order in which
+  # validations are declared matters and this gives the subclasses control of that.
+  module QuoteCostValidations
+    extend ActiveSupport::Concern
+
+    included do
+      validates :user_chosen_cost_type,
+                inclusion: { in: PriorAuthority::Steps::QuoteCostForm::COST_TYPES, allow_nil: false },
+                if: :variable_cost_type?
+
+      validates :items, presence: true, numericality: { greater_than: 0 }, if: :per_item?
+      validates :cost_per_item, presence: true, numericality: { greater_than: 0 }, if: :per_item?
+
+      validates :period, presence: true, time_period: true, if: :per_hour?
+      validates :cost_per_hour, presence: true, numericality: { greater_than: 0 }, if: :per_hour?
+    end
+  end
+end

--- a/app/forms/prior_authority/steps/additional_costs/overview_form.rb
+++ b/app/forms/prior_authority/steps/additional_costs/overview_form.rb
@@ -6,8 +6,7 @@ module PriorAuthority
         validates :additional_costs_still_to_add, inclusion: { in: [true, false] }
 
         def additional_costs
-          application.additional_costs
-                     .map { AdditionalCosts::DetailForm.build(_1, application:) }
+          application.additional_costs.map { AdditionalCosts::DetailForm.build(_1, application:) }
         end
 
         def costs_added

--- a/app/forms/prior_authority/steps/additional_costs/overview_form.rb
+++ b/app/forms/prior_authority/steps/additional_costs/overview_form.rb
@@ -6,7 +6,8 @@ module PriorAuthority
         validates :additional_costs_still_to_add, inclusion: { in: [true, false] }
 
         def additional_costs
-          application.additional_costs.map { AdditionalCosts::DetailForm.build(_1, application:) }
+          application.additional_costs
+                     .map { AdditionalCosts::DetailForm.build(_1, application:) }
         end
 
         def costs_added

--- a/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
@@ -1,17 +1,29 @@
 module PriorAuthority
   module Steps
     module AlternativeQuotes
-      class DetailForm < ::Steps::BaseFormObject
+      class DetailForm < PriorAuthority::Steps::QuoteCostForm
         include Rails.application.routes.url_helpers
 
         attribute :id, :string
         attribute :contact_full_name, :string
         attribute :organisation, :string
         attribute :postcode, :string
+        attribute :travel_time, :time_period
+        attribute :travel_cost_per_hour, :decimal, precision: 10, scale: 2
+        attribute :additional_cost_list, :string
+        attribute :additional_cost_total, :decimal, precision: 10, scale: 2
 
         validates :contact_full_name, presence: true
         validates :organisation, presence: true
         validates :postcode, presence: true, uk_postcode: true
+
+        include QuoteCostValidations
+
+        validates :travel_time, time_period: true
+
+        def total_cost
+          main_cost + travel_cost + additional_cost
+        end
 
         def http_verb
           record.persisted? ? :patch : :post
@@ -25,10 +37,24 @@ module PriorAuthority
           end
         end
 
+        def main_cost
+          per_item? ? item_cost : time_cost
+        end
+
+        def travel_cost
+          return 0 unless travel_cost_per_hour.to_i.positive? && travel_time.to_i.positive?
+
+          (travel_cost_per_hour * (travel_time.hours + (travel_time.minutes / 60.0))).round(2)
+        end
+
+        def additional_cost
+          additional_cost_total.to_f
+        end
+
         private
 
         def persist!
-          record.update!(attributes.except('id'))
+          record.update!(attributes.except('id', 'service_type'))
         end
       end
     end

--- a/app/forms/prior_authority/steps/alternative_quotes/overview_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/overview_form.rb
@@ -3,7 +3,7 @@ module PriorAuthority
     module AlternativeQuotes
       class OverviewForm < ::Steps::BaseFormObject
         attribute :alternative_quotes_still_to_add, :boolean
-        validates :alternative_quotes_still_to_add, inclusion: { in: [true, false] }
+        validates :alternative_quotes_still_to_add, inclusion: { in: [true, false] }, if: :more_quotes_addable?
 
         attribute :no_alternative_quote_reason, :string
 
@@ -15,6 +15,10 @@ module PriorAuthority
 
         def quotes_added
           application.alternative_quotes.count
+        end
+
+        def more_quotes_addable?
+          quotes_added < 3
         end
 
         private

--- a/app/forms/prior_authority/steps/alternative_quotes/overview_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/overview_form.rb
@@ -10,8 +10,7 @@ module PriorAuthority
         validates :no_alternative_quote_reason, presence: true, if: :no_alternative_quotes?
 
         def alternative_quotes
-          application.alternative_quotes
-                     .map { AlternativeQuotes::DetailForm.build(_1, application:) }
+          application.alternative_quotes.map { AlternativeQuotes::DetailForm.build(_1, application:) }
         end
 
         def quotes_added

--- a/app/forms/prior_authority/steps/alternative_quotes/overview_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/overview_form.rb
@@ -10,7 +10,8 @@ module PriorAuthority
         validates :no_alternative_quote_reason, presence: true, if: :no_alternative_quotes?
 
         def alternative_quotes
-          application.alternative_quotes.map { AlternativeQuotes::DetailForm.build(_1, application:) }
+          application.alternative_quotes
+                     .map { AlternativeQuotes::DetailForm.build(_1, application:) }
         end
 
         def quotes_added

--- a/app/forms/prior_authority/steps/delete_travel_form.rb
+++ b/app/forms/prior_authority/steps/delete_travel_form.rb
@@ -8,7 +8,7 @@ module PriorAuthority
       private
 
       def persist!
-        application.update!(
+        record.update!(
           travel_cost_reason: nil,
           travel_time: nil,
           travel_cost_per_hour: nil

--- a/app/forms/prior_authority/steps/primary_quote_form.rb
+++ b/app/forms/prior_authority/steps/primary_quote_form.rb
@@ -12,6 +12,13 @@ module PriorAuthority
           attrs.delete('service_type')
           attrs.delete('custom_service_name')
         else
+
+          # This ensures that the 'service type suggestion' field in the UI is
+          # is pre-populated with the custom name
+          if attrs[:application].service_type == 'custom'
+            attrs[:application].service_type = attrs[:application].custom_service_name
+          end
+
           # But otherwise, we need to pull in application-wide settings to this quote-specific model
           attrs[:service_type] ||= attrs[:application].service_type
           attrs[:custom_service_name] ||= attrs[:application].custom_service_name

--- a/app/forms/prior_authority/steps/primary_quote_form.rb
+++ b/app/forms/prior_authority/steps/primary_quote_form.rb
@@ -1,6 +1,25 @@
 module PriorAuthority
   module Steps
     class PrimaryQuoteForm < ::Steps::BaseFormObject
+      def self.attribute_names
+        super - %w[service_type custom_service_name]
+      end
+
+      def initialize(attrs)
+        # We have logic to set these below if a service type suggestion is provided,
+        # and we don't want the arbitrary order of attribute assignment to overwrite that
+        if attrs['service_type_suggestion'].present?
+          attrs.delete('service_type')
+          attrs.delete('custom_service_name')
+        else
+          # But otherwise, we need to pull in application-wide settings to this quote-specific model
+          attrs[:service_type] ||= attrs[:application].service_type
+          attrs[:custom_service_name] ||= attrs[:application].custom_service_name
+        end
+
+        super(attrs)
+      end
+
       attribute :service_type, :value_object, source: QuoteServices
       attribute :custom_service_name, :string
       attribute :contact_full_name, :string
@@ -32,7 +51,9 @@ module PriorAuthority
       private
 
       def persist!
-        record.update!(attributes.merge(default_attributes))
+        record.update!(attributes.except('service_type', 'custom_service_name')
+                                 .merge(default_attributes))
+        application.update(service_type:, custom_service_name:)
       end
 
       def default_attributes

--- a/app/forms/prior_authority/steps/primary_quote_form.rb
+++ b/app/forms/prior_authority/steps/primary_quote_form.rb
@@ -54,6 +54,13 @@ module PriorAuthority
         record.update!(attributes.except('service_type', 'custom_service_name')
                                  .merge(default_attributes))
         application.update(service_type:, custom_service_name:)
+
+        # If a change to service type has rendered any alternative quotes invalid,
+        # delete them because we don't yet have a UI for highlighting invalidities
+        # from the overview screen
+        application.alternative_quotes
+                   .reject { AlternativeQuotes::DetailForm.build(_1, application:).valid? }
+                   .each(&:destroy)
       end
 
       def default_attributes

--- a/app/forms/prior_authority/steps/quote_cost_form.rb
+++ b/app/forms/prior_authority/steps/quote_cost_form.rb
@@ -24,14 +24,6 @@ module PriorAuthority
       attribute :period, :time_period
       attribute :cost_per_hour, :decimal, precision: 10, scale: 2
 
-      validates :user_chosen_cost_type, inclusion: { in: COST_TYPES, allow_nil: false }, if: :variable_cost_type?
-
-      validates :items, presence: true, numericality: { greater_than: 0 }, if: :per_item?
-      validates :cost_per_item, presence: true, numericality: { greater_than: 0 }, if: :per_item?
-
-      validates :period, presence: true, time_period: true, if: :per_hour?
-      validates :cost_per_hour, presence: true, numericality: { greater_than: 0 }, if: :per_hour?
-
       def variable_cost_type?
         service_rule.cost_type == :variable
       end

--- a/app/forms/prior_authority/steps/quote_cost_form.rb
+++ b/app/forms/prior_authority/steps/quote_cost_form.rb
@@ -1,0 +1,90 @@
+module PriorAuthority
+  module Steps
+    class QuoteCostForm < ::Steps::BaseFormObject
+      def self.attribute_names
+        super - %w[service_type]
+      end
+
+      def initialize(attrs)
+        attrs[:service_type] = attrs[:application].service_type
+
+        super(attrs)
+      end
+
+      PER_ITEM = 'per_item'.freeze
+      PER_HOUR = 'per_hour'.freeze
+      VARIABLE = 'variable'.freeze
+      COST_TYPES = [PER_ITEM, PER_HOUR].freeze
+
+      attribute :service_type, :value_object, source: QuoteServices
+
+      attribute :user_chosen_cost_type, :string
+      attribute :items, :integer
+      attribute :cost_per_item, :decimal, precision: 10, scale: 2
+      attribute :period, :time_period
+      attribute :cost_per_hour, :decimal, precision: 10, scale: 2
+
+      validates :user_chosen_cost_type, inclusion: { in: COST_TYPES, allow_nil: false }, if: :variable_cost_type?
+
+      validates :items, presence: true, numericality: { greater_than: 0 }, if: :per_item?
+      validates :cost_per_item, presence: true, numericality: { greater_than: 0 }, if: :per_item?
+
+      validates :period, presence: true, time_period: true, if: :per_hour?
+      validates :cost_per_hour, presence: true, numericality: { greater_than: 0 }, if: :per_hour?
+
+      def variable_cost_type?
+        service_rule.cost_type == :variable
+      end
+
+      def formatted_total_cost
+        NumberTo.pounds(total_cost)
+      end
+
+      def total_cost
+        per_item? ? item_cost : time_cost
+      end
+
+      def per_item?
+        cost_type == PER_ITEM
+      end
+
+      def per_hour?
+        cost_type == PER_HOUR
+      end
+
+      def item_type
+        service_rule.item
+      end
+
+      def service_name
+        service_type.translated
+      end
+
+      def cost_type
+        variable_cost_type? ? user_chosen_cost_type : enforced_cost_type
+      end
+
+      private
+
+      def enforced_cost_type
+        service_rule.cost_type == :per_item ? PER_ITEM : PER_HOUR
+      end
+
+      def item_cost
+        return 0 unless cost_per_item.to_f.positive? && items.to_i.positive?
+
+        cost_per_item * items
+      end
+
+      def time_cost
+        return 0 unless cost_per_hour.to_i.positive? && period.to_i.positive?
+
+        (cost_per_hour * (period.hours + (period.minutes / 60.0))).round(2)
+      end
+
+      def service_rule
+        @service_rule ||= ServiceTypeRule.build(service_type)
+      end
+    end
+  end
+end

--- a/app/forms/prior_authority/steps/quote_cost_form.rb
+++ b/app/forms/prior_authority/steps/quote_cost_form.rb
@@ -7,7 +7,6 @@ module PriorAuthority
 
       def initialize(attrs)
         attrs[:service_type] = attrs[:application].service_type
-
         super(attrs)
       end
 

--- a/app/forms/prior_authority/steps/service_cost_form.rb
+++ b/app/forms/prior_authority/steps/service_cost_form.rb
@@ -1,8 +1,8 @@
 module PriorAuthority
   module Steps
-    class ServiceCostForm < ::Steps::BaseFormObject
+    class ServiceCostForm < QuoteCostForm
       def self.attribute_names
-        super - %w[prior_authority_granted service_type]
+        super - %w[prior_authority_granted]
       end
 
       def initialize(attrs)
@@ -14,97 +14,24 @@ module PriorAuthority
           attrs[:prior_authority_granted] = attrs[:application].prior_authority_granted
         end
 
-        attrs[:service_type] = attrs[:application].service_type
-
         super(attrs)
       end
-
-      PER_ITEM = 'per_item'.freeze
-      PER_HOUR = 'per_hour'.freeze
-      VARIABLE = 'variable'.freeze
-      COST_TYPES = [PER_ITEM, PER_HOUR].freeze
-
-      attribute :service_type, :value_object, source: QuoteServices
 
       attribute :prior_authority_granted, :boolean
       attribute :ordered_by_court, :boolean
       attribute :related_to_post_mortem, :boolean
-      attribute :user_chosen_cost_type, :string
-      attribute :items, :integer
-      attribute :cost_per_item, :decimal, precision: 10, scale: 2
-      attribute :period, :time_period
-      attribute :cost_per_hour, :decimal, precision: 10, scale: 2
 
       validates :prior_authority_granted, inclusion: { in: [true, false], allow_nil: false }
       validates :ordered_by_court, inclusion: { in: [true, false], allow_nil: false }, if: :court_order_relevant
       validates :related_to_post_mortem, inclusion: { in: [true, false], allow_nil: false }, if: :post_mortem_relevant
-      validates :user_chosen_cost_type, inclusion: { in: COST_TYPES, allow_nil: false }, if: :variable_cost_type?
-
-      validates :items, presence: true, numericality: { greater_than: 0 }, if: :per_item?
-      validates :cost_per_item, presence: true, numericality: { greater_than: 0 }, if: :per_item?
-
-      validates :period, presence: true, time_period: true, if: :per_hour?
-      validates :cost_per_hour, presence: true, numericality: { greater_than: 0 }, if: :per_hour?
 
       delegate :court_order_relevant, :post_mortem_relevant, to: :service_rule
 
-      def variable_cost_type?
-        service_rule.cost_type == :variable
-      end
-
-      def formatted_total_cost
-        NumberTo.pounds(total_cost)
-      end
-
-      def total_cost
-        per_item? ? item_cost : time_cost
-      end
-
-      def per_item?
-        cost_type == PER_ITEM
-      end
-
-      def per_hour?
-        cost_type == PER_HOUR
-      end
-
-      def item_type
-        service_rule.item
-      end
-
-      def service_name
-        service_type.translated
-      end
-
-      def cost_type
-        variable_cost_type? ? user_chosen_cost_type : enforced_cost_type
-      end
-
       private
-
-      def enforced_cost_type
-        service_rule.cost_type == :per_item ? PER_ITEM : PER_HOUR
-      end
-
-      def item_cost
-        return 0 unless cost_per_item.to_f.positive? && items.to_i.positive?
-
-        cost_per_item * items
-      end
-
-      def time_cost
-        return 0 unless cost_per_hour.to_i.positive? && period.to_i.positive?
-
-        (cost_per_hour * (period.hours + (period.minutes / 60.0))).round(2)
-      end
 
       def persist!
         record.update!(attributes.except('prior_authority_granted', 'service_type'))
         application.update(prior_authority_granted:)
-      end
-
-      def service_rule
-        @service_rule ||= ServiceTypeRule.build(service_type)
       end
     end
   end

--- a/app/forms/prior_authority/steps/service_cost_form.rb
+++ b/app/forms/prior_authority/steps/service_cost_form.rb
@@ -25,6 +25,8 @@ module PriorAuthority
       validates :ordered_by_court, inclusion: { in: [true, false], allow_nil: false }, if: :court_order_relevant
       validates :related_to_post_mortem, inclusion: { in: [true, false], allow_nil: false }, if: :post_mortem_relevant
 
+      include QuoteCostValidations
+
       delegate :court_order_relevant, :post_mortem_relevant, to: :service_rule
 
       private

--- a/app/forms/prior_authority/steps/service_cost_form.rb
+++ b/app/forms/prior_authority/steps/service_cost_form.rb
@@ -2,7 +2,7 @@ module PriorAuthority
   module Steps
     class ServiceCostForm < ::Steps::BaseFormObject
       def self.attribute_names
-        super - ['prior_authority_granted']
+        super - %w[prior_authority_granted service_type]
       end
 
       def initialize(attrs)
@@ -14,8 +14,8 @@ module PriorAuthority
           attrs[:prior_authority_granted] = attrs[:application].prior_authority_granted
         end
 
-        # This will be nil when loaded on update, populated on edit
-        attrs[:service_type] ||= attrs[:record].service_type
+        attrs[:service_type] = attrs[:application].service_type
+
         super(attrs)
       end
 
@@ -99,7 +99,7 @@ module PriorAuthority
       end
 
       def persist!
-        record.update!(attributes.except('prior_authority_granted'))
+        record.update!(attributes.except('prior_authority_granted', 'service_type'))
         application.update(prior_authority_granted:)
       end
 

--- a/app/forms/prior_authority/steps/travel_detail_form.rb
+++ b/app/forms/prior_authority/steps/travel_detail_form.rb
@@ -26,7 +26,7 @@ module PriorAuthority
       private
 
       def persist!
-        application.update!(attributes)
+        record.update!(attributes)
       end
     end
   end

--- a/app/presenters/prior_authority/primary_quote_summary.rb
+++ b/app/presenters/prior_authority/primary_quote_summary.rb
@@ -29,7 +29,10 @@ module PriorAuthority
     end
 
     def travel_detail_form
-      @travel_detail_form ||= Steps::TravelDetailForm.build(application)
+      @travel_detail_form ||= Steps::TravelDetailForm.build(
+        application.primary_quote,
+        application:,
+      )
     end
 
     def additional_cost_overview_form

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -17,8 +17,9 @@ class SubmitToAppStore
 
       ATTRIBUTES = %i[
         id
-        service_type
-        custom_service_name
+        travel_time
+        travel_cost_per_hour
+        travel_cost_reason
         contact_full_name
         organisation
         postcode

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -30,6 +30,8 @@ class SubmitToAppStore
         cost_per_item
         items
         period
+        additional_cost_list
+        additional_cost_total
       ].freeze
     end
   end

--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -63,9 +63,6 @@ class SubmitToAppStore
 
     def convenience_attributes
       {
-        # N.B We do `detect(&:primary)` instead of `.primary_quote` to make resilient to cases
-        # where the quotes are not persisted to the database
-        service_type: application.quotes.detect(&:primary).service_type,
         firm_name: application.firm_office.name,
         client_name: application.defendant.full_name
       }
@@ -90,9 +87,8 @@ class SubmitToAppStore
       psychiatric_liaison
       psychiatric_liaison_reason_not
       next_hearing
-      travel_time
-      travel_cost_per_hour
-      travel_cost_reason
+      service_type
+      custom_service_name
       prior_authority_granted
       no_alternative_quote_reason
     ].freeze

--- a/app/views/prior_authority/steps/additional_cost_details/edit.html.erb
+++ b/app/views/prior_authority/steps/additional_cost_details/edit.html.erb
@@ -32,13 +32,12 @@
                                     hint: { text: t('.cost_per_hour_hint') } %>
         <% end %>
       <% end %>
-
-      <%= form.refresh_button(button: :update_calculation_no_article) %>
+      <%= form.reload_button(button: :update_calculation_no_article) %>
       <span class="govuk-caption-l"><%= t('.total_cost') %></span>
       <h2 class="govuk-heading-l">
         <%= @form_object.formatted_total_cost %>
       </h2>
-      <%= form.continue_button %>
+      <%= form.continue_button secondary: false %>
     <% end %>
   </div>
 </div>

--- a/app/views/prior_authority/steps/alternative_quote_details/edit.html.erb
+++ b/app/views/prior_authority/steps/alternative_quote_details/edit.html.erb
@@ -15,7 +15,35 @@
       <%= form.govuk_text_field :organisation, label: { text: t('.organisation'), size: 's' } %>
       <%= form.govuk_text_field :postcode, label: { text: t('.postcode'), size: 's' } %>
 
-      <%= form.continue_button %>
+      <h2 class="govuk-heading-m"><%= t('.cost', service_name: @form_object.service_name) %></h2>
+      <%= render 'prior_authority/steps/service_cost/cost_fields', form: form %>
+
+      <h2 class="govuk-heading-m"><%= t('.travel_cost') %></h2>
+      <p class="govuk-text"><%= t('.travel_cost_hint') %></p>
+      <%= form.govuk_period_field :travel_time, legend: { text: t('.travel_time'), size: 's' } %>
+      <%= form.govuk_text_field :travel_cost_per_hour,
+                                width: 5,
+                                prefix_text: "&pound;".html_safe,
+                                inputmode: "decimal",
+                                label: { text: t('.hourly_cost'), size: 's' } %>
+
+      <h2 class="govuk-heading-m"><%= t('.additional_costs') %></h2>
+      <p class="govuk-text"><%= t('.additional_costs_hint') %></p>
+      <%= form.govuk_text_area :additional_cost_list, label: { text: t('.additional_cost_list'), size: 's' } %>
+      <%= form.govuk_text_field :additional_cost_total,
+                                width: 5,
+                                prefix_text: "&pound;".html_safe,
+                                inputmode: "decimal",
+                                label: { text: t('.additional_cost_total'), size: 's' } %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+      <%= form.reload_button(button: :update_calculation_no_article) %>
+      <span class="govuk-caption-l"><%= t('.total_cost') %></span>
+      <h2 class="govuk-heading-l" id="totalTravelCost">
+        <%= @form_object.formatted_total_cost %>
+      </h2>
+
+      <%= form.continue_button secondary: false %>
     <% end %>
   </div>
 </div>

--- a/app/views/prior_authority/steps/alternative_quotes/_last_quote_deleted.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/_last_quote_deleted.html.erb
@@ -2,21 +2,25 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
+    <%= govuk_notification_banner(title_text: t('prior_authority.steps.alternative_quotes.important'),
+                                  text: t('prior_authority.steps.alternative_quotes.deleted'),
+                                  success: true) %>
+    <span class="govuk-caption-xl"><%= t(".caption") %></span>
+    <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <%= step_form @form_object do |form| %>
+
       <%= govuk_error_summary(@form_object) %>
-      <span class="govuk-caption-xl"><%= t(".caption") %></span>
       <%= form.govuk_radio_buttons_fieldset :alternative_quotes_still_to_add,
-                                            legend: { text: t('.page_title'), size: 'xl', tag: 'h1' } do %>
+                                            legend: { text: t('.add_one'), size: 's' } do %>
+        <%= form.govuk_radio_button :alternative_quotes_still_to_add,
+                                    true,
+                                    label: { text: t('prior_authority.generic.yes_choice') } %>
         <%= form.govuk_radio_button :alternative_quotes_still_to_add,
                                     false,
                                     label: { text: t('prior_authority.generic.no_choice') },
                                     link_errors: true do %>
           <%= form.govuk_text_area :no_alternative_quote_reason, label: { text: t('.why_not') } %>
         <% end %>
-        <%= form.govuk_radio_button :alternative_quotes_still_to_add,
-                                    true,
-                                    label: { text: t('prior_authority.generic.yes_choice') } %>
       <% end %>
 
       <%= form.continue_button %>

--- a/app/views/prior_authority/steps/alternative_quotes/_quote_summary.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/_quote_summary.html.erb
@@ -25,7 +25,54 @@
         </dd>
       </div>
       <%# TODO: CRM457-1105 Add file upload summary here %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= t('.additional_items') %></dt>
+        <dd class="govuk-summary-list__value">
+          <% if alternative_quote.additional_cost_list.present? %>
+            <% alternative_quote.additional_cost_list.split("\n").map do |line| %>
+              <%= line %>
+              <br>
+            <% end %>
+          <% else %>
+            <%= t('.none') %>
+          <% end %>
+        </dd>
+      </div>
     </dl>
-      <%# TODO: CRM457-1106 Add cost summary here %>
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-visually-hidden">
+        <%= t('.alternative_quote') %>
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t('.costs') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.total') %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= t('.service') %></td>
+          <td class="govuk-table__cell">
+            <%= NumberTo.pounds(alternative_quote.main_cost) %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= t('.travel') %></td>
+          <td class="govuk-table__cell">
+            <%= NumberTo.pounds(alternative_quote.travel_cost) %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= t('.additional') %></td>
+          <td class="govuk-table__cell">
+            <%= NumberTo.pounds(alternative_quote.additional_cost) %>
+          </td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-table__header"><%= t('.total_cost') %></td>
+          <td class="govuk-table__cell"><strong><%= NumberTo.pounds(alternative_quote.total_cost) %></strong></td>
+        </tr>
+    </tbody>
+    </table>
   </div>
 </div>

--- a/app/views/prior_authority/steps/alternative_quotes/_with_alternative_quotes.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/_with_alternative_quotes.html.erb
@@ -19,15 +19,16 @@
     <%= step_form @form_object do |form| %>
 
       <%= govuk_error_summary(@form_object) %>
-      <%= form.govuk_collection_radio_buttons(
-        :alternative_quotes_still_to_add,
-        YesNoAnswer.radio_options,
-        :value,
-        :label,
-        inline: true,
-        legend: { text: t('.question'), size: 's' }
-      ) %>
-
+      <% if @form_object.more_quotes_addable? %>
+        <%= form.govuk_collection_radio_buttons(
+          :alternative_quotes_still_to_add,
+          YesNoAnswer.radio_options,
+          :value,
+          :label,
+          inline: true,
+          legend: { text: t('.question'), size: 's' }
+        ) %>
+      <% end %>
       <%= form.continue_button %>
     <% end %>
   </div>

--- a/app/views/prior_authority/steps/alternative_quotes/edit.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/edit.html.erb
@@ -1,6 +1,9 @@
 <% decision_step_header %>
+<%# TODO: Use a custom UI if no alternative quotes and params[:deleted] %>
 <% if @form_object.alternative_quotes.any? %>
   <%= render 'with_alternative_quotes' %>
+<% elsif params[:deleted] %>
+  <%= render 'last_quote_deleted' %>
 <% else %>
   <%= render 'no_alternative_quotes' %>
 <% end %>

--- a/app/views/prior_authority/steps/alternative_quotes/edit.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/edit.html.erb
@@ -1,5 +1,4 @@
 <% decision_step_header %>
-<%# TODO: Use a custom UI if no alternative quotes and params[:deleted] %>
 <% if @form_object.alternative_quotes.any? %>
   <%= render 'with_alternative_quotes' %>
 <% elsif params[:deleted] %>

--- a/app/views/prior_authority/steps/primary_quote_summary/_service_cost_card.html.erb
+++ b/app/views/prior_authority/steps/primary_quote_summary/_service_cost_card.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-summary-card">
+<div id="service-cost-card" class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title"><%= t('.service_costs') %></h2>
     <ul class="govuk-summary-card__actions">

--- a/app/views/prior_authority/steps/service_cost/_cost_fields.html.erb
+++ b/app/views/prior_authority/steps/service_cost/_cost_fields.html.erb
@@ -1,0 +1,14 @@
+<% if @form_object.variable_cost_type? %>
+  <%= form.govuk_radio_buttons_fieldset :user_chosen_cost_type, legend: { text: t('.user_chosen_cost_type'), size: 's' } do %>
+    <%= form.govuk_radio_button :user_chosen_cost_type, @form_object.class::PER_ITEM, label: { text: t('.per_item') }, link_errors: true do %>
+      <%= render 'prior_authority/steps/service_cost/items', form: form, size: nil %>
+    <% end %>
+    <%= form.govuk_radio_button :user_chosen_cost_type, @form_object.class::PER_HOUR, label: { text: t('.per_hour') } do %>
+      <%= render 'prior_authority/steps/service_cost/time', form: form, size: nil %>
+    <% end %>
+  <% end %>
+<% elsif @form_object.per_item? %>
+  <%= render 'prior_authority/steps/service_cost/items', form: form, size: 's' %>
+<% else %>
+  <%= render 'prior_authority/steps/service_cost/time', form: form, size: 's' %>
+<% end %>

--- a/app/views/prior_authority/steps/service_cost/edit.html.erb
+++ b/app/views/prior_authority/steps/service_cost/edit.html.erb
@@ -36,20 +36,7 @@
           ) %>
       <% end %>
       <h2 class="govuk-heading-m"><%= @form_object.service_name %></h2>
-      <% if @form_object.variable_cost_type? %>
-        <%= form.govuk_radio_buttons_fieldset :user_chosen_cost_type, legend: { text: t('.user_chosen_cost_type'), size: 's' } do %>
-          <%= form.govuk_radio_button :user_chosen_cost_type, @form_object.class::PER_ITEM, label: { text: t('.per_item') }, link_errors: true do %>
-            <%= render 'items', form: form, size: nil %>
-          <% end %>
-          <%= form.govuk_radio_button :user_chosen_cost_type, @form_object.class::PER_HOUR, label: { text: t('.per_hour') } do %>
-            <%= render 'time', form: form, size: nil %>
-          <% end %>
-        <% end %>
-      <% elsif @form_object.per_item? %>
-        <%= render 'items', form: form, size: 's' %>
-      <% else %>
-        <%= render 'time', form: form, size: 's' %>
-      <% end %>
+      <%= render 'cost_fields', form: form %>
       <%= form.refresh_button(button: :update_calculation_no_article) %>
       <span class="govuk-caption-l"><%= t('.total_cost') %></span>
       <h2 class="govuk-heading-l">
@@ -59,5 +46,3 @@
     <% end %>
   </div>
 </div>
-
-

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -194,15 +194,6 @@ en:
             travel_cost_per_hour:
               blank: Enter the cost per hour
               greater_than: The cost per hour must be more than 0
-            cost_per_hour:
-              blank: Enter the hourly cost
-              greater_than: The hourly cost must be more than 0
-            items:
-              blank: Enter the number of items
-              greater_than: The number of items must be more than 0
-            cost_per_item:
-              blank: Enter the cost per item
-              greater_than: The cost per item must be more than 0
         prior_authority/steps/additional_costs/overview_form:
           attributes:
             additional_costs_still_to_add:
@@ -223,6 +214,15 @@ en:
               invalid_minutes: The number of minutes must be between 0 and 59
               invalid_period: Time must be more than 0
               invalid: Time must be valid
+            cost_per_hour:
+              blank: Enter the hourly cost
+              greater_than: The hourly cost must be more than 0
+            items:
+              blank: Enter the number of items
+              greater_than: The number of items must be more than 0
+            cost_per_item:
+              blank: Enter the cost per item
+              greater_than: The cost per item must be more than 0
         prior_authority/steps/reason_why_form:
           attributes:
             reason_why:

--- a/config/locales/en/prior_authority/alternative_quotes.yml
+++ b/config/locales/en/prior_authority/alternative_quotes.yml
@@ -11,11 +11,24 @@ en:
           page_title: You've added %{number} alternative %{quote}
           quote: quote
           question: Do you want to add an additional quote?
+        last_quote_deleted:
+          caption: About the request
+          page_title: You've added 0 alternative quotes
+          add_one: Do you want to add an additional quote?
+          why_not: Why did you not get other quotes?
         quote_summary:
           alternative_quote: Alternative quote
           change: Change
           delete: Delete
           service_details: Service details
+          additional_items: Additional items
+          none: None
+          costs: Costs
+          total: Total
+          service: Service
+          travel: Travel
+          additional: Additional
+          total_cost: Total cost
         important: Important
         deleted: The alternative quote was deleted
       alternative_quote_details:
@@ -32,6 +45,16 @@ en:
           contact_full_name: Contact full name
           organisation: Organisation
           postcode: Postcode
+          cost: "%{service_name} cost"
+          travel_cost: Travel cost (optional)
+          travel_cost_hint: Only include the hourly rate cost. Any other travel expenditure (such as mileage, parking and travel fares) can be added as additional costs.
+          travel_time: Time
+          hourly_cost: What is the hourly cost?
+          additional_costs: Additional costs (optional)
+          additional_costs_hint: For example, other costs such as extra fees, travel mileage, parking charges or travel fares.
+          additional_cost_list: List additional costs
+          additional_cost_total: Total additional costs
+          total_cost: Total quote cost
   activemodel:
     errors:
       models:
@@ -50,3 +73,31 @@ en:
             postcode:
               blank: Enter the postcode
               invalid: Enter a real postcode
+            user_chosen_cost_type:
+              inclusion: Select how you are being charged
+            period:
+              blank: Enter the time
+              blank_hours: The number of hours must be a number
+              invalid_hours: The number of hours must be 0 or more
+              blank_minutes: The number of minutes must be a number
+              invalid_minutes: The number of minutes must be between 0 and 59
+              invalid_period: Time must be more than 0
+              invalid: Time must be valid
+            cost_per_hour:
+              blank: Enter the hourly cost
+              greater_than: The hourly cost must be more than 0
+            items:
+              blank: Enter the number of items
+              greater_than: The number of items must be more than 0
+            cost_per_item:
+              blank: Enter the cost per item
+              greater_than: The cost per item must be more than 0
+            travel_time:
+              blank_hours: The number of hours must be a number
+              invalid_hours: The number of hours must be 0 or more
+              blank_minutes: The number of minutes must be a number
+              invalid_minutes: The number of minutes must be between 0 and 59
+              invalid_period: Travel time must be more than 0
+              invalid: Travel time must be valid
+            travel_cost_per_hour:
+              greater_than: The cost per hour must be more than 0

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -99,6 +99,7 @@ en:
           ordered_by_court: Was this report ordered by the court?
           related_to_post_mortem: Is this related to a post-mortem?
           total_cost: Total cost
+        cost_fields:
           user_chosen_cost_type: How are you being charged?
           per_item: Charged per item
           per_hour: Charged by the hour

--- a/db/migrate/20240208143129_move_fields_around.rb
+++ b/db/migrate/20240208143129_move_fields_around.rb
@@ -1,0 +1,19 @@
+class MoveFieldsAround < ActiveRecord::Migration[7.1]
+  def change
+    change_table :prior_authority_applications, bulk: true do |t|
+      t.string :service_type
+      t.string :custom_service_name
+      t.remove :travel_time, type: :integer
+      t.remove :travel_cost_per_hour, type: :decimal, precision: 10, scale: 2
+      t.remove :travel_cost_reason, type: :text
+    end
+
+    change_table :quotes, bulk: true do |t|
+      t.remove :service_type, type: :string
+      t.remove :custom_service_name, type: :string
+      t.integer :travel_time
+      t.decimal :travel_cost_per_hour, precision: 10, scale: 2
+      t.text :travel_cost_reason
+    end
+  end
+end

--- a/db/migrate/20240208165017_add_additional_costs_to_quote.rb
+++ b/db/migrate/20240208165017_add_additional_costs_to_quote.rb
@@ -1,0 +1,6 @@
+class AddAdditionalCostsToQuote < ActiveRecord::Migration[7.1]
+  def change
+    add_column :quotes, :additional_cost_list, :text
+    add_column :quotes, :additional_cost_total, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_143129) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_165017) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -253,6 +253,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_143129) do
     t.integer "travel_time"
     t.decimal "travel_cost_per_hour", precision: 10, scale: 2
     t.text "travel_cost_reason"
+    t.text "additional_cost_list"
+    t.decimal "additional_cost_total", precision: 10, scale: 2
     t.index ["prior_authority_application_id"], name: "index_quotes_on_prior_authority_application_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_101924) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_143129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -204,13 +204,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_101924) do
     t.boolean "psychiatric_liaison"
     t.string "psychiatric_liaison_reason_not"
     t.boolean "next_hearing"
-    t.integer "travel_time"
-    t.decimal "travel_cost_per_hour", precision: 10, scale: 2
-    t.text "travel_cost_reason"
     t.boolean "additional_costs_still_to_add"
     t.boolean "prior_authority_granted"
     t.text "no_alternative_quote_reason"
     t.boolean "alternative_quotes_still_to_add"
+    t.string "service_type"
+    t.string "custom_service_name"
     t.index ["firm_office_id"], name: "index_prior_authority_applications_on_firm_office_id"
     t.index ["provider_id"], name: "index_prior_authority_applications_on_provider_id"
     t.index ["solicitor_id"], name: "index_prior_authority_applications_on_solicitor_id"
@@ -237,8 +236,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_101924) do
   end
 
   create_table "quotes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "service_type"
-    t.string "custom_service_name"
     t.string "contact_full_name"
     t.string "organisation"
     t.string "postcode"
@@ -253,6 +250,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_101924) do
     t.decimal "cost_per_item", precision: 10, scale: 2
     t.integer "items"
     t.integer "period"
+    t.integer "travel_time"
+    t.decimal "travel_cost_per_hour", precision: 10, scale: 2
+    t.text "travel_cost_reason"
     t.index ["prior_authority_application_id"], name: "index_quotes_on_prior_authority_application_id"
   end
 

--- a/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
+++ b/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
@@ -28,7 +28,6 @@ module Steps
     def update_and_advance(form_class, opts = {})
       hash = permitted_params(form_class).to_h
       record = opts.fetch(:record, current_application)
-
       @form_object = form_class.new(
         hash.merge(application: current_application, record: record)
       )

--- a/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
+++ b/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
@@ -16,6 +16,10 @@ module Steps
     def update
       raise 'implement this action, if needed, in subclasses'
     end
+
+    def reload
+      raise 'implement this action, if needed, in subclasses'
+    end
     # :nocov:
 
     private
@@ -36,6 +40,8 @@ module Steps
         # Validations will not be run when saving a draft
         @form_object.save!
         redirect_to opts[:after_commit_redirect_path] || nsm_after_commit_path(id: current_application.id)
+      elsif params.key?(:reload)
+        reload
       elsif params.key?(:save_and_refresh)
         @form_object.save!
         redirect_to_current_object

--- a/gems/laa_multi_step_forms/app/helpers/laa_multi_step_forms/form_builder_helper.rb
+++ b/gems/laa_multi_step_forms/app/helpers/laa_multi_step_forms/form_builder_helper.rb
@@ -20,6 +20,10 @@ module LaaMultiStepForms
       submit_button(button, opts.merge(secondary: true, name: 'save_and_refresh'))
     end
 
+    def reload_button(button: :update_calculation, opts: {})
+      submit_button(button, opts.merge(secondary: true, name: 'reload'))
+    end
+
     def continue_button(primary: :save_and_continue, secondary: :save_and_come_back_later,
                         primary_opts: {}, secondary_opts: {})
       submit_button(primary, primary_opts) do

--- a/gems/laa_multi_step_forms/docs/Steps.md
+++ b/gems/laa_multi_step_forms/docs/Steps.md
@@ -80,6 +80,12 @@ with the current step, and either running the validations and saving it or just
 saving the data (this is done when saving a draft version). It also redirects to
 the next step based on the `decision_tree_class` (see Routing between steps).
 
+There are a few "magic" params that will cause special behaviour to be applied here:
+
+* `commit_draft` will skip validations and redirect to `after_commit_redirect_path`. This is used for the "Save and come back later" flow
+* `reload` will skip validations, not persist data, and re-render the page. This is used to updatean on-screen calculation based on data entered so far without persisting anything in the database (particularly relevant when dealing with "add another" forms)
+* `save_and_refresh` will skip validations, persist the data, and redirect back to the same page again
+
 ### additional_permitted_params
 
 By default the `update_and_advance` method will permit params based on the attributes

--- a/gems/laa_multi_step_forms/spec/controllers/steps/base_step_controller_spec.rb
+++ b/gems/laa_multi_step_forms/spec/controllers/steps/base_step_controller_spec.rb
@@ -267,6 +267,41 @@ RSpec.describe DummyStepController, type: :controller do
       end
     end
 
+    context 'when reloading (without save)' do
+      let(:form) { instance_double(Steps::BaseFormObject, application:, record:) }
+      let(:record) { application }
+      let(:params) { { id: application.id, test_model: { first: 1, second: 2 }, reload: true } }
+
+      it 'sets the paramters on the form' do
+        expect(form_class).to receive(:new)
+          .with({ 'application' => application,
+                  'record' => application,
+                  'first' => '1',
+                  'second' => '2' })
+
+        put :update, params:
+      end
+
+      context 'additional/missing params are passed in' do
+        let(:params) { { id: application.id, test_model: { first: 1, third: 3 }, reload: true } }
+
+        it 'ignore additional and skips missing params' do
+          expect(form_class).to receive(:new)
+            .with({ 'application' => application,
+                    'record' => application,
+                    'first' => '1' })
+
+          put :update, params:
+        end
+      end
+
+      it 'calls the subclass implementation of reload' do
+        put(:update, params:)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     context 'when saving the record' do
       let(:params) { { id: application.id, test_model: { first: 1, second: 2 } } }
 

--- a/gems/laa_multi_step_forms/spec/dummy/app/controllers/dummy_step_controller.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/app/controllers/dummy_step_controller.rb
@@ -25,6 +25,10 @@ class DummyStepController < ::Steps::BaseStepController
     true
   end
 
+  def reload
+    head(:ok)
+  end
+
   def decision_tree_class
     DummyStepImplementation.decision_tree_class || super
   end

--- a/gems/laa_multi_step_forms/spec/helpers/form_builder_helper_spec.rb
+++ b/gems/laa_multi_step_forms/spec/helpers/form_builder_helper_spec.rb
@@ -56,6 +56,50 @@ foo: 'bar' }
     end
   end
 
+  describe '#reload_button' do
+    context 'standard button' do
+      let(:expected_markup) do
+        '<button type="submit" formnovalidate="formnovalidate" class="govuk-button govuk-button--secondary" ' \
+          'data-module="govuk-button" data-prevent-double-click="true" name="reload">' \
+          'Update the calculation</button>'
+      end
+
+      it 'outputs only the continue button' do
+        expect(
+          builder.reload_button
+        ).to eq(expected_markup)
+      end
+    end
+
+    context 'button text can be customised' do
+      before do
+        # Ensure we don't rely on specific locales, so we have predictable tests
+        allow(I18n).to receive(:t).with('helpers.submit.refresh').and_return('Refresh')
+      end
+
+      it 'outputs the buttons with specific text' do
+        html = builder.reload_button(button: :refresh)
+        doc = Nokogiri::HTML.fragment(html)
+
+        assert_select(doc, 'button', attributes: { name: 'save_and_refresh' }, text: 'Refresh')
+      end
+    end
+
+    context 'custom attributes' do
+      it 'outputs the buttons with additional attributes' do
+        html = builder.reload_button(
+          opts: { class: 'custom-class-secondary', foo: 'bar' }
+        )
+        doc = Nokogiri::HTML.fragment(html)
+
+        assert_select(
+          doc, 'button', attributes: { class: 'govuk-button govuk-button--secondary custom-class-secondary',
+foo: 'bar' }
+        )
+      end
+    end
+  end
+
   describe '#continue_button' do
     context 'when there is no secondary action' do
       let(:expected_markup) do

--- a/spec/controllers/prior_authority/primary_quote_controller_spec.rb
+++ b/spec/controllers/prior_authority/primary_quote_controller_spec.rb
@@ -11,15 +11,19 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteController, type: :controller 
   describe '#primary_quote' do
     context 'non custom primary quote service' do
       it 'returns a quote with non custom service type' do
-        expect(subject.send(:primary_quote)).to eq(quote)
+        expect(subject.send(:record)).to eq(quote)
       end
     end
 
     context 'custom primary quote service' do
-      let(:quote) { build(:quote, :primary, :custom) }
+      let(:application) do
+        build(:prior_authority_application,
+              primary_quote: quote, service_type: 'custom', custom_service_name: 'random service')
+      end
 
       it 'returns a quote with non custom service type' do
-        expect(subject.send(:primary_quote).service_type).to eq('random service')
+        subject.send(:set_service_type)
+        expect(subject.send(:current_application).service_type).to eq('random service')
       end
     end
   end

--- a/spec/controllers/prior_authority/primary_quote_controller_spec.rb
+++ b/spec/controllers/prior_authority/primary_quote_controller_spec.rb
@@ -14,17 +14,5 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteController, type: :controller 
         expect(subject.send(:record)).to eq(quote)
       end
     end
-
-    context 'custom primary quote service' do
-      let(:application) do
-        build(:prior_authority_application,
-              primary_quote: quote, service_type: 'custom', custom_service_name: 'random service')
-      end
-
-      it 'returns a quote with non custom service type' do
-        subject.send(:set_service_type)
-        expect(subject.send(:current_application).service_type).to eq('random service')
-      end
-    end
   end
 end

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -56,8 +56,9 @@ FactoryBot.define do
       with_defendant
       with_case_details
       with_psychiatric_liaison
-      primary_quote factory: %i[quote primary variable_cost], strategy: :build
+      primary_quote factory: %i[quote primary], strategy: :build
       ufn { '123456/001' }
+      service_type { 'meteorologist' }
       prior_authority_granted { true }
       after(:create) do |paa, _a|
         create(:defendant, :valid_paa, defendable_id: paa.id, defendable_type: paa.class.to_s)
@@ -90,9 +91,9 @@ FactoryBot.define do
       supporting_documents { build_list(:supporting_document, 2) }
       quotes { build_list(:quote, 1, :primary) }
       prior_authority_granted { false }
-      travel_cost_per_hour {  50.0 }
-      travel_time { 150 }
       no_alternative_quote_reason { 'a reason' }
+      service_type { 'pathologist' }
+      custom_service_name { nil }
     end
   end
 end

--- a/spec/factories/quote.rb
+++ b/spec/factories/quote.rb
@@ -8,20 +8,20 @@ FactoryBot.define do
     travel_cost_per_hour { 50.0 }
     travel_time { 150 }
     user_chosen_cost_type { 'per_hour' }
-  end
 
-  trait :blank do
-    contact_full_name { nil }
-    organisation { nil }
-    postcode { nil }
-    primary { nil }
-  end
+    trait :blank do
+      contact_full_name { nil }
+      organisation { nil }
+      postcode { nil }
+      primary { nil }
+    end
 
-  trait :primary do
-    primary { true }
-  end
+    trait :primary do
+      primary { true }
+    end
 
-  trait :additional do
-    primary { false }
+    trait :alternative do
+      primary { false }
+    end
   end
 end

--- a/spec/factories/quote.rb
+++ b/spec/factories/quote.rb
@@ -1,31 +1,20 @@
 FactoryBot.define do
   factory :quote do
-    service_type { 'pathologist' }
-    custom_service_name { nil }
     contact_full_name { 'Joe Bloggs' }
     organisation { 'LAA' }
     postcode { 'CR0 1RE' }
     cost_per_hour { 10 }
     period { 180 }
+    travel_cost_per_hour { 50.0 }
+    travel_time { 150 }
+    user_chosen_cost_type { 'per_hour' }
   end
 
   trait :blank do
-    service_type { nil }
     contact_full_name { nil }
-    custom_service_name { nil }
     organisation { nil }
     postcode { nil }
     primary { nil }
-  end
-
-  trait :custom do
-    service_type { 'custom' }
-    custom_service_name { 'random service' }
-  end
-
-  trait :variable_cost do
-    service_type { 'meteorologist' }
-    user_chosen_cost_type { 'per_hour' }
   end
 
   trait :primary do

--- a/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
+++ b/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
   end
 
   let(:record) { instance_double(Quote) }
-  let(:application) { instance_double(PriorAuthorityApplication) }
+  let(:application) { instance_double(PriorAuthorityApplication, service_type: 'forensics') }
   let(:service_type) { 'forensics_expert' }
   let(:custom_service_name) { '' }
   let(:contact_full_name) { 'Joe Bloggs' }

--- a/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
+++ b/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
   let(:arguments) do
     {
       record:,
+      application:,
       service_type:,
+      custom_service_name:,
       contact_full_name:,
       organisation:,
       postcode:,
@@ -14,7 +16,9 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
   end
 
   let(:record) { instance_double(Quote) }
-  let(:service_type) { 'Forensics Expert' }
+  let(:application) { instance_double(PriorAuthorityApplication) }
+  let(:service_type) { 'forensics_expert' }
+  let(:custom_service_name) { '' }
   let(:contact_full_name) { 'Joe Bloggs' }
   let(:organisation) { 'LAA' }
   let(:postcode) { 'CR0 1RE' }
@@ -64,7 +68,8 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
   describe '#save' do
     subject(:save) { form.save }
 
-    let(:record) { create(:quote, :blank, prior_authority_application: create(:prior_authority_application)) }
+    let(:record) { create(:quote, :blank, prior_authority_application: application) }
+    let(:application) { create(:prior_authority_application) }
 
     context 'with valid quote details' do
       let(:service_type) { 'Forensics Expert' }
@@ -76,7 +81,6 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
         expect { save }.to change { record.reload.attributes }
           .from(
             hash_including(
-              'service_type' => nil,
               'contact_full_name' => nil,
               'organisation' => nil,
               'postcode' => nil,
@@ -85,12 +89,25 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
           )
           .to(
             hash_including(
-              'service_type' => 'Forensics Expert',
-              'custom_service_name' => nil,
               'contact_full_name' => 'Joe Bloggs',
               'organisation' => 'LAA',
               'postcode' => 'CR0 1RE',
               'primary' => true
+            )
+          )
+      end
+
+      it 'persists the application changes' do
+        expect { save }.to change { application.reload.attributes }
+          .from(
+            hash_including(
+              'service_type' => nil,
+            )
+          )
+          .to(
+            hash_including(
+              'service_type' => 'Forensics Expert',
+              'custom_service_name' => '',
             )
           )
       end
@@ -106,7 +123,6 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
         expect { save }.not_to change { record.reload.attributes }
           .from(
             hash_including(
-              'service_type' => nil,
               'contact_full_name' => nil,
               'organisation' => nil,
               'postcode' => nil,

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -85,7 +85,9 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
             id: application.primary_quote.id,
             travel_cost_per_hour: '50.0',
             travel_cost_reason: nil,
-            travel_time: 150
+            travel_time: 150,
+            additional_cost_list: nil,
+            additional_cost_total: nil,
           }
         ],
         additional_costs: []

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -24,12 +24,10 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         next_hearing: true,
         office_code: '1A123B',
         service_type: 'pathologist',
+        custom_service_name: nil,
         firm_name: 'Firm A',
         client_name: 'bob jim',
         prior_authority_granted: false,
-        travel_cost_per_hour: '50.0',
-        travel_cost_reason: nil,
-        travel_time: 150,
         no_alternative_quote_reason: 'a reason',
         defendant: {
           first_name: 'bob',
@@ -73,8 +71,6 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         ],
         quotes: [
           {
-            service_type: 'pathologist',
-            custom_service_name: nil,
             contact_full_name: 'Joe Bloggs',
             organisation: 'LAA',
             postcode: 'CR0 1RE',
@@ -86,7 +82,10 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
             items: nil,
             ordered_by_court: nil,
             related_to_post_mortem: nil,
-            id: application.primary_quote.id
+            id: application.primary_quote.id,
+            travel_cost_per_hour: '50.0',
+            travel_cost_reason: nil,
+            travel_time: 150
           }
         ],
         additional_costs: []

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -38,10 +38,29 @@ RSpec.describe 'Prior authority applications - alternative quote' do
         fill_in 'Contact full name', with: 'Mrs Expert'
         fill_in 'Organisation', with: 'ExpertiseCo'
         fill_in 'Postcode', with: 'SW1 1AA'
+        choose 'Charged per item'
+        fill_in 'Number of items', with: '2'
+        fill_in 'What is the cost per item?', with: '3'
         click_on 'Save and continue'
 
         expect(page).to have_content "You've added 1 alternative quote"
         expect(page).to have_content 'Mrs Expert'
+      end
+
+      it 'does maths for me' do
+        fill_in 'Contact full name', with: 'Mrs Expert'
+        fill_in 'Organisation', with: 'ExpertiseCo'
+        fill_in 'Postcode', with: 'SW1 1AA'
+        choose 'Charged per item'
+        fill_in 'Number of items', with: '1'
+        fill_in 'What is the cost per item?', with: '100'
+        fill_in 'prior_authority_steps_alternative_quotes_detail_form_travel_time_1i', with: '1'
+        fill_in 'prior_authority_steps_alternative_quotes_detail_form_travel_time_2i', with: '0'
+        fill_in 'What is the hourly cost?', with: '50'
+        fill_in 'Total additional costs', with: '5'
+        click_on 'Update calculation'
+
+        expect(page).to have_content 'Total quote cost £155.00'
       end
 
       it 'validates' do
@@ -54,6 +73,9 @@ RSpec.describe 'Prior authority applications - alternative quote' do
           fill_in 'Contact full name', with: 'Mrs Expert'
           fill_in 'Organisation', with: 'ExpertiseCo'
           fill_in 'Postcode', with: 'SW1 1AA'
+          choose 'Charged per item'
+          fill_in 'Number of items', with: '2'
+          fill_in 'What is the cost per item?', with: '3'
           click_on 'Save and continue'
         end
 
@@ -79,13 +101,30 @@ RSpec.describe 'Prior authority applications - alternative quote' do
           expect(page).to have_content 'Are you sure you want to delete this alternative quote?'
           click_on 'Yes, delete it'
           expect(page).to have_content 'The alternative quote was deleted'
-          expect(page).to have_content 'Have you got other quotes?'
+          expect(page).to have_content 'Do you want to add an additional quote?'
         end
 
         it 'allows me to cancel deletion' do
           click_on 'Delete'
           click_on 'No, do not delete it'
           expect(page).to have_content "You've added 1 alternative quote"
+        end
+
+        it 'deletes the quote if it is invalidated by a service type change' do
+          choose 'No'
+          click_on 'Save and continue'
+          click_on 'Primary quote'
+          within '#service-cost-card' do
+            click_on 'Change'
+          end
+          # Charged per hour, not per item
+          select 'Animal Behaviourist', from: 'Service required'
+          click_on 'Save and continue'
+          fill_in_service_cost(cost_type: :per_hour)
+
+          # Leave primary quote summary screen
+          click_on 'Save and continue'
+          expect(page).to have_content 'Alternative quotesNot started'
         end
       end
     end

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -129,4 +129,16 @@ RSpec.describe 'Prior authority applications - alternative quote' do
       end
     end
   end
+
+  context 'when I already have 3 quotes' do
+    before do
+      create_list(:quote, 3, :alternative, prior_authority_application: application)
+    end
+
+    it 'does not prompt me to add more' do
+      click_on 'Alternative quotes'
+      click_on 'Save and continue'
+      expect(page).to have_content 'Alternative quotesCompleted'
+    end
+  end
 end

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'Prior authority applications - alternative quote' do
 
           # Leave primary quote summary screen
           click_on 'Save and continue'
-          expect(page).to have_content 'Alternative quotesNot started'
+          expect(page).to have_content 'Alternative quotesIn progress'
         end
       end
     end

--- a/spec/system/prior_authority/primary_quote_spec.rb
+++ b/spec/system/prior_authority/primary_quote_spec.rb
@@ -9,19 +9,28 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
     expect(page).to have_content 'Primary quote Cannot yet start'
   end
 
-  it 'allows primary quote creation' do
-    fill_in_until_step(:primary_quote)
-    click_on 'Primary quote'
-    expect(page).to have_title 'Primary quote'
+  context 'when I fill in a primary quote' do
+    before do
+      fill_in_until_step(:primary_quote)
+      click_on 'Primary quote'
+      expect(page).to have_title 'Primary quote'
 
-    fill_in 'Service required', with: 'Forensics'
-    fill_in 'Contact full name', with: 'Joe Bloggs'
-    fill_in 'Organisation', with: 'LAA'
-    fill_in 'Postcode', with: 'CR0 1RE'
+      fill_in 'Service required', with: 'Custom Forensics'
+      fill_in 'Contact full name', with: 'Joe Bloggs'
+      fill_in 'Organisation', with: 'LAA'
+      fill_in 'Postcode', with: 'CR0 1RE'
+    end
 
-    click_on 'Save and continue'
+    it 'allows primary quote creation' do
+      click_on 'Save and continue'
+      expect(page).to have_content 'Service cost'
+    end
 
-    expect(page).to have_content 'Service cost'
+    it 'pre-populates the text field with a custom service name' do
+      click_on 'Save and continue'
+      click_on 'Back'
+      expect(page).to have_field 'Service required', with: 'Custom Forensics'
+    end
   end
 
   it 'validates primary quote fields fields' do

--- a/spec/system/support/prior_authority/step_helpers.rb
+++ b/spec/system/support/prior_authority/step_helpers.rb
@@ -152,11 +152,19 @@ module PriorAuthority
       click_on 'Save and continue'
     end
 
-    def fill_in_service_cost
+    def fill_in_service_cost(cost_type: :variable)
       choose 'Yes'
-      choose 'Charged per item'
-      fill_in 'Number of items', with: '5'
-      fill_in 'What is the cost per item?', with: '1.23'
+      choose 'Charged per item' if cost_type == :variable
+
+      if cost_type == :per_hour
+        fill_in 'Hours', with: '1'
+        fill_in 'Minutes', with: '0'
+        fill_in 'Hourly cost', with: '100'
+      else
+        fill_in 'Number of items', with: '5'
+        fill_in 'What is the cost per item?', with: '1.23'
+      end
+
       click_on 'Save and continue'
     end
   end


### PR DESCRIPTION
## Description of change
- Add cost fields to alternative quote details page and summary
- Add newly defined third summary UI (for when the only additional quote has just been deleted)
- Remove 'save and come back later' from both add-another screens at designer's request
- Stop 'Update calculation' from saving an invalid add-another entity
- Move 'service cost' out of individual quotes, as it applies to all quotes
- Move travel cost details into individual quotes, as there are different travel costs per quote

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1106)

## Notes for reviewer

## Screenshots of changes (if applicable)

<img width="666" alt="Screenshot 2024-02-09 at 10 45 43" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/113888736/d1dd2469-95cc-4189-ba99-264199c40a57">

---

<img width="471" alt="Screenshot 2024-02-09 at 10 46 11" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/113888736/567cb10d-e252-47c6-af27-6ade6b6d5080">

---

<img width="535" alt="Screenshot 2024-02-09 at 10 46 21" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/113888736/bd251c06-ef07-4267-bddf-53b955c37585">

