### PR TITLE
CRM457-978: Add MAAT number format validation

### DIFF
--- a/app/forms/prior_authority/steps/case_detail/defendant_form.rb
+++ b/app/forms/prior_authority/steps/case_detail/defendant_form.rb
@@ -3,7 +3,7 @@ module PriorAuthority
     module CaseDetail
       class DefendantForm < ::Steps::BaseFormObject
         attribute :maat, :string
-        validates :maat, presence: true
+        validates :maat, presence: true, format: { with: /\A\d+\z/ }
 
         private
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -70,9 +70,11 @@ en:
           attributes:
             maat:
               blank: Enter the MAAT number
+              invalid: The MAAT number must only contain numbers
           summary:
             maat:
               blank: Enter the MAAT number
+              invalid: The MAAT number must only contain numbers
         prior_authority/steps/client_detail_form:
           attributes:
             first_name:

--- a/spec/forms/prior_authority/steps/case_detail/defendant_form_spec.rb
+++ b/spec/forms/prior_authority/steps/case_detail/defendant_form_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe PriorAuthority::Steps::CaseDetail::DefendantForm do
         expect(form.errors.messages[:maat]).to include('Enter the MAAT number')
       end
     end
+
+    context 'with invalid format of MAAT number' do
+      let(:maat) { 'A12345' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:maat, :invalid)).to be(true)
+        expect(form.errors.messages[:maat]).to include('The MAAT number must only contain numbers')
+      end
+    end
   end
 
   describe '#save' do
@@ -45,10 +55,18 @@ RSpec.describe PriorAuthority::Steps::CaseDetail::DefendantForm do
       end
     end
 
-    context 'with invalid defendant details' do
+    context 'with blank MAAT number details' do
       let(:maat) { '' }
 
-      it 'does not persists to persist the solicitor' do
+      it 'does not persists to persist the defendant' do
+        expect { save }.not_to change { application.reload.defendant }.from(nil)
+      end
+    end
+
+    context 'with invalid format of MAAT number' do
+      let(:maat) { 'A23456' }
+
+      it 'does not persist the defendant' do
         expect { save }.not_to change { application.reload.defendant }.from(nil)
       end
     end

--- a/spec/forms/prior_authority/steps/case_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/case_detail_form_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe PriorAuthority::Steps::CaseDetailForm do
         }
       end
 
-      it 'has a validation error on the field' do
+      it 'has validation errors' do
         expect(form).not_to be_valid
         expect(form.errors.messages.values.flatten)
           .to include('Enter the main offence',


### PR DESCRIPTION
## Description of change
Add MAAT number format validation

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-978)

Must only be digits.  Error message inline with
designs.

[errors spreadsheet](https://docs.google.com/spreadsheets/d/1p79PoMhECgMiCDB_qQGTvCALflGjiHMDnPNA8n7mtcc/edit#gid=1083653105)

