### PR TITLE
CRM457-1132: Add confirmations to check your answers

### DIFF
--- a/app/controllers/prior_authority/steps/base_controller.rb
+++ b/app/controllers/prior_authority/steps/base_controller.rb
@@ -3,6 +3,10 @@ module PriorAuthority
     class BaseController < ::Steps::BaseStepController
       layout 'prior_authority'
 
+      before_action :check_completed, only: :edit
+
+      def edit; end
+
       private
 
       def decision_tree_class
@@ -26,6 +30,14 @@ module PriorAuthority
       def prune_navigation_stack
         # The default behaviour of prune_navigation_stack assumes linear completion of tasks
         # which doesn't apply to Prior Authority. So we do a noop instead.
+      end
+
+      def check_completed
+        redirect_to prior_authority_steps_start_page_path(current_application) if answers_checked?
+      end
+
+      def answers_checked?
+        PriorAuthority::Tasks::CheckAnswers.new(application: current_application).completed?
       end
     end
   end

--- a/app/controllers/prior_authority/steps/check_answers_controller.rb
+++ b/app/controllers/prior_authority/steps/check_answers_controller.rb
@@ -6,19 +6,30 @@ module PriorAuthority
       #
       # before_action :check_complete?
 
+      before_action :build_report
+
       def edit
-        @application = current_application
         @application.update!(navigation_stack: stack_with_step_moved_to_end)
 
-        @report = CheckAnswers::Report.new(@application)
+        @form_object = CheckAnswersForm.build(
+          current_application
+        )
       end
 
-      # TODO: CRM457-1132 check answers confirmation form
       def update
-        # update_and_advance(CheckAnswersForm, as:, after_commit_redirect_path:)
+        update_and_advance(CheckAnswersForm, as:, after_commit_redirect_path:)
       end
 
       private
+
+      def as
+        :check_answers
+      end
+
+      def build_report
+        @application = current_application
+        @report = CheckAnswers::Report.new(@application)
+      end
 
       def stack_with_step_moved_to_end
         stack_with_step_moved_to_end = @application.navigation_stack.delete_if { |step| step == request.fullpath }

--- a/app/controllers/prior_authority/steps/check_answers_controller.rb
+++ b/app/controllers/prior_authority/steps/check_answers_controller.rb
@@ -1,7 +1,7 @@
 module PriorAuthority
   module Steps
     class CheckAnswersController < BaseController
-      before_action :check_completed, :build_report
+      before_action :build_report
 
       def edit
         current_application.update!(navigation_stack: stack_with_step_moved_to_end)
@@ -27,14 +27,6 @@ module PriorAuthority
         end
         stack_with_step_moved_to_end << request.fullpath
         stack_with_step_moved_to_end
-      end
-
-      def check_completed
-        redirect_to prior_authority_steps_start_page_path(current_application) if answers_checked?
-      end
-
-      def answers_checked?
-        PriorAuthority::Tasks::CheckAnswers.new(application: current_application).completed?
       end
 
       def build_report

--- a/app/controllers/prior_authority/steps/submission_confirmation_controller.rb
+++ b/app/controllers/prior_authority/steps/submission_confirmation_controller.rb
@@ -1,0 +1,9 @@
+module PriorAuthority
+  module Steps
+    class SubmissionConfirmationController < BaseController
+      def show
+        @laa_reference = current_application.laa_reference
+      end
+    end
+  end
+end

--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -1,0 +1,22 @@
+module PriorAuthority
+  module Steps
+    class CheckAnswersForm < ::Steps::BaseFormObject
+      attribute :confirm_excluding_vat, :boolean
+      attribute :confirm_travel_expenditure, :boolean
+
+      validates :confirm_excluding_vat, acceptance: { accept: true }, allow_nil: false
+      validates :confirm_travel_expenditure, acceptance: { accept: true }, allow_nil: false
+
+      def persist!
+        application.update!(attributes)
+
+        # TODO: placeholder for possible logic to actually submit
+        # PriorAuthorityApplication.transaction do
+        #   application.status = :submitted
+        #   application.update!(attributes)
+        #   SubmitToAppStore.new.process(submission: application)
+        # end
+      end
+    end
+  end
+end

--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -10,12 +10,12 @@ module PriorAuthority
       def persist!
         application.update!(attributes)
 
-        # TODO: placeholder for possible logic to actually submit
-        # PriorAuthorityApplication.transaction do
-        #   application.status = :submitted
-        #   application.update!(attributes)
-        #   SubmitToAppStore.new.process(submission: application)
-        # end
+        # TODO: actually submit to app store
+        PriorAuthorityApplication.transaction do
+          application.status = :submitted
+          application.update!(attributes)
+          # SubmitToAppStore.new.process(submission: application)
+        end
       end
     end
   end

--- a/app/presenters/prior_authority/check_answers/primary_quote_card.rb
+++ b/app/presenters/prior_authority/check_answers/primary_quote_card.rb
@@ -38,7 +38,7 @@ module PriorAuthority
           *related_to_post_mortem,
           {
             head_key: 'quote_upload',
-            text: 'TODO',
+            text: primary_quote.document.file_name,
           },
           *ordered_by_court,
           {

--- a/app/services/decisions/decision_tree.rb
+++ b/app/services/decisions/decision_tree.rb
@@ -87,7 +87,11 @@ module Decisions
     from(:equality_questions).goto(edit: 'nsm/steps/solicitor_declaration')
     from(:solicitor_declaration).goto(show: 'nsm/steps/claim_confirmation')
 
-    # prior authority pre-draft application steps
+    # ---------------------------------
+    # prior authority application steps
+    # ---------------------------------
+
+    # pre-draft application steps
     from(:prison_law).goto(edit: 'prior_authority/steps/authority_value')
     from(:authority_value).goto(edit: 'prior_authority/steps/ufn')
     from(:ufn)
@@ -95,9 +99,6 @@ module Decisions
       .goto(edit: PRIOR_AUTHORITY_CHECK_ANSWERS)
       .goto(show: PRIOR_AUTHORITY_START_PAGE)
 
-    # ---------------------------------
-    # prior authority application steps
-    # ---------------------------------
     from(:case_contact)
       .when(-> { application.navigation_stack[-1].match?('check_answers') })
       .goto(edit: PRIOR_AUTHORITY_CHECK_ANSWERS)
@@ -166,5 +167,8 @@ module Decisions
       .when(-> { application.navigation_stack[-1].match?('check_answers') })
       .goto(edit: PRIOR_AUTHORITY_CHECK_ANSWERS)
       .goto(show: PRIOR_AUTHORITY_START_PAGE)
+
+    from(:check_answers)
+      .goto(show: 'prior_authority/steps/submission_confirmation')
   end
 end

--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -91,6 +91,8 @@ class SubmitToAppStore
       custom_service_name
       prior_authority_granted
       no_alternative_quote_reason
+      confirm_excluding_vat
+      confirm_travel_expenditure
     ].freeze
   end
 end

--- a/app/views/prior_authority/steps/check_answers/edit.html.erb
+++ b/app/views/prior_authority/steps/check_answers/edit.html.erb
@@ -10,14 +10,24 @@
         <%= govuk_summary_list(**section) %>
       <% end %>
     <% end %>
-    <div class="govuk-button-group">
-      <%# TODO: accept and send path %>
-      <%= link_to '', class: "govuk-button", data_module: "govuk-button", data_prevent_double_click: "true" do %>
-        Accept and send
+
+    <h2 class="govuk-heading-l"><%= t('.subheading') %></h2>
+
+    <%= govuk_error_summary(@form_object) %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_check_boxes_fieldset :confirm_excluding_vat, multiple: false, legend: nil do %>
+        <%= f.govuk_check_box :confirm_excluding_vat, 1, 0, multiple: false, link_errors: true, label: { text: t('.confirmations.excluding_vat') } %>
       <% end %>
-      <%= link_to prior_authority_root_path(anchor: 'drafts'), class: "govuk-button govuk-button--secondary", data_module: "govuk-button", data_prevent_double_click: "true" do %>
-        Save and come back later
+
+      <%= f.govuk_check_boxes_fieldset :confirm_travel_expenditure, multiple: false, legend: nil do %>
+        <%= f.govuk_check_box :confirm_travel_expenditure, 1, 0, multiple: false, link_errors: true, label: { text: t('.confirmations.travel_expenditure') } %>
       <% end %>
-    </div>
+
+      <p class="govuk-body">
+        <%= t('.confirmations.blurb') %>
+      </p>
+      <%= f.continue_button(primary: :accept_and_send) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/prior_authority/steps/primary_quote_summary/_service_cost_card.html.erb
+++ b/app/views/prior_authority/steps/primary_quote_summary/_service_cost_card.html.erb
@@ -25,7 +25,7 @@
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><%= t('.service_quote_upload') %></dt>
         <dd class="govuk-summary-list__value">
-          <%= quote.document.file_name %>
+          <%= quote.document&.file_name %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/app/views/prior_authority/steps/submission_confirmation/show.html.erb
+++ b/app/views/prior_authority/steps/submission_confirmation/show.html.erb
@@ -1,0 +1,35 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        <%= t('.panel_heading')%>
+      </h1>
+      <div class="govuk-panel__body">
+        <%= t('.panel_text')%><br><strong><%= @laa_reference%></strong>
+      </div>
+    </div>
+
+    <div class="govuk-!-margin-top-4 govuk-!-margin-bottom-6">
+    <p class="govuk-body"><%= t('.confirmation_email_sent')%></p>
+      <h2 class="govuk-heading-m"><%= t('.next_steps.title')%></h2>
+      <p class="govuk-body"><%= t('.next_steps.process_1')%></p>
+      <p class="govuk-body"><%= t('.next_steps.process_2')%></p>
+      <p class="govuk-body">
+          <a href="#" class="govuk-link"><%= t('.feedback.link_text')%></a>
+          (<%= t('.feedback.description')%>)
+      </p>
+      <h2 class="govuk-heading-m"><%= t('.print_application.title')%></h2>
+      <p class="govuk-body"><%= t('.print_application.instructions')%></p>
+    </div>
+
+    <div class="govuk-button-group confirmation-button-group">
+      <%= link_button t('helpers.view_applications'), prior_authority_applications_path, class: 'govuk-button' %>
+      <%= button_to prior_authority_applications_path, class: "govuk-button govuk-button--secondary" do %>
+        <%= t('helpers.start_new_application')%>
+      <% end %>
+    </div>
+  </div>
+</div>
+

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -74,6 +74,12 @@ en:
               blank: Enter the name of the prison
             subject_to_poca:
               inclusion: Select yes if this case is subject to POCA (Proceeds of Crime Act 2002)?
+        prior_authority/steps/check_answers_form:
+          attributes:
+            confirm_excluding_vat:
+              accepted: Select if you confirm that all costs are exclusive of VAT
+            confirm_travel_expenditure:
+              accepted: Select if you confirm that any travel expenditure (such as mileage, parking and travel fares) is included as additional items in the primary quote, and is not included as part of any hourly rate
         prior_authority/steps/case_detail/defendant_form:
           attributes:
             maat:

--- a/config/locales/en/prior_authority/check_answers.yml
+++ b/config/locales/en/prior_authority/check_answers.yml
@@ -4,8 +4,18 @@ en:
     steps:
       check_answers:
         edit:
-          page_title: Check your answers
+          confirmations:
+            blurb: |
+              By submitting this application you are confirming that, to the best of your
+              knowledge, the details you are providing are correct.
+
+            excluding_vat: I confirm that all costs are exclusive of VAT
+            travel_expenditure: |
+              I confirm that any travel expenditure (such as mileage, parking and travel fares)
+              is included as additional items in the primary quote, and is not included as part
+              of any hourly rate
           heading: Check your answers
+          page_title: Check your answers
           sections:
             alternative_quotes:
               quote_summary: "Quote %{count}"
@@ -47,6 +57,7 @@ en:
               laa_reference: LAA reference
               prison_law: Prison law
               ufn: Unique file number
+          subheading: Now send your application
 
         groups:
           about_case:

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -226,3 +226,19 @@ en:
           page_title: Are you sure you want to delete this additional cost?
           yes_delete: Yes, delete it
           no_delete: No, do not delete it
+      submission_confirmation:
+        show:
+          page_title: Application complete
+          panel_heading: Application complete
+          panel_text: Your LAA reference number
+          print_application:
+            title: How to print your application
+            instructions: If needed you can view all of your submitted applications and print them.
+          confirmation_email_sent: We have sent you a confirmation email.
+          next_steps:
+            title: What happens next
+            process_1: We'll assess your application.
+            process_2: We’ll send you an email to either accept your application or to ask for more information.
+          feedback:
+            link_text: What did you think of this service?
+            description: takes 30 seconds

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
         end
         upload_step :reason_why
         edit_step :check_answers
+        show_step :submission_confirmation
       end
     end
 

--- a/db/migrate/20240216084333_add_confirmations_to_prior_authority_applications.rb
+++ b/db/migrate/20240216084333_add_confirmations_to_prior_authority_applications.rb
@@ -1,0 +1,8 @@
+class AddConfirmationsToPriorAuthorityApplications < ActiveRecord::Migration[7.1]
+  def change
+    change_table :prior_authority_applications, bulk: true do |t|
+      t.boolean :confirm_excluding_vat
+      t.boolean :confirm_travel_expenditure
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_165017) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_16_084333) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -191,25 +191,27 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_165017) do
     t.jsonb "navigation_stack", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "reason_why"
-    t.string "main_offence"
-    t.date "rep_order_date"
-    t.boolean "client_detained"
-    t.string "client_detained_prison"
-    t.boolean "subject_to_poca"
+    t.boolean "next_hearing"
     t.date "next_hearing_date"
     t.string "plea"
     t.string "court_type"
     t.boolean "youth_court"
     t.boolean "psychiatric_liaison"
     t.string "psychiatric_liaison_reason_not"
-    t.boolean "next_hearing"
+    t.string "main_offence"
+    t.date "rep_order_date"
+    t.boolean "client_detained"
+    t.string "client_detained_prison"
+    t.boolean "subject_to_poca"
+    t.text "reason_why"
     t.boolean "additional_costs_still_to_add"
     t.boolean "prior_authority_granted"
     t.text "no_alternative_quote_reason"
     t.boolean "alternative_quotes_still_to_add"
     t.string "service_type"
     t.string "custom_service_name"
+    t.boolean "confirm_excluding_vat"
+    t.boolean "confirm_travel_expenditure"
     t.index ["firm_office_id"], name: "index_prior_authority_applications_on_firm_office_id"
     t.index ["provider_id"], name: "index_prior_authority_applications_on_provider_id"
     t.index ["solicitor_id"], name: "index_prior_authority_applications_on_solicitor_id"

--- a/gems/laa_multi_step_forms/config/locales/en/helpers.yml
+++ b/gems/laa_multi_step_forms/config/locales/en/helpers.yml
@@ -8,7 +8,9 @@ en:
   helpers:
     back_link: Back
     start_again: Start again
+    start_new_application: Start new application
     start_new_claim: Start a new claim
+    view_applications: View my applications
     view_claims: View my claims
     submit:
       accept_and_send: Accept and send

--- a/gems/laa_multi_step_forms/config/locales/en/helpers.yml
+++ b/gems/laa_multi_step_forms/config/locales/en/helpers.yml
@@ -11,6 +11,7 @@ en:
     start_new_claim: Start a new claim
     view_claims: View my claims
     submit:
+      accept_and_send: Accept and send
       save_and_continue: Save and continue
       save_and_come_back_later: Save and come back later
       save_and_submit: Save and submit

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -76,6 +76,11 @@ FactoryBot.define do
       end
     end
 
+    trait :with_confirmations do
+      confirm_excluding_vat { true }
+      confirm_travel_expenditure { true }
+    end
+
     trait :full do
       with_firm_and_solicitor
       with_defendant

--- a/spec/forms/prior_authority/steps/check_answers_form_spec.rb
+++ b/spec/forms/prior_authority/steps/check_answers_form_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe PriorAuthority::Steps::CheckAnswersForm do
+  subject(:form) { described_class.new(arguments) }
+
+  let(:arguments) do
+    {
+      application:,
+      confirm_excluding_vat:,
+      confirm_travel_expenditure:,
+    }
+  end
+
+  describe '#validate' do
+    let(:application) { instance_double(PriorAuthorityApplication) }
+
+    context 'with all confirmations accepted' do
+      let(:confirm_excluding_vat) { 'true' }
+      let(:confirm_travel_expenditure) { 'true' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with confirm_excluding_vat not accepted' do
+      let(:confirm_excluding_vat) { 'false' }
+      let(:confirm_travel_expenditure) { 'true' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:confirm_excluding_vat, :accepted)).to be(true)
+        expect(form.errors.messages[:confirm_excluding_vat])
+          .to include('Select if you confirm that all costs are exclusive of VAT')
+      end
+    end
+
+    context 'with confirm_travel_expenditure not accepted' do
+      let(:confirm_excluding_vat) { 'true' }
+      let(:confirm_travel_expenditure) { 'false' }
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.of_kind?(:confirm_travel_expenditure, :accepted)).to be(true)
+        expect(form.errors.messages[:confirm_travel_expenditure])
+          .to include(
+            'Select if you confirm that any travel expenditure (such as mileage, ' \
+            'parking and travel fares) is included as additional items in the primary ' \
+            'quote, and is not included as part of any hourly rate'
+          )
+      end
+    end
+  end
+
+  describe '#save' do
+    subject(:save) { form.save }
+
+    let(:application) { create(:prior_authority_application) }
+
+    context 'with all confirmations accepted' do
+      let(:confirm_excluding_vat) { 'true' }
+      let(:confirm_travel_expenditure) { 'true' }
+
+      it 'persists the value' do
+        expect { save }.to change { application.reload.attributes }
+          .from(
+            hash_including(
+              'confirm_excluding_vat' => nil,
+              'confirm_travel_expenditure' => nil,
+            )
+          )
+          .to(
+            hash_including(
+              'confirm_excluding_vat' => true,
+              'confirm_travel_expenditure' => true,
+            )
+          )
+      end
+    end
+
+    context 'with unaccepted confirmations' do
+      let(:confirm_excluding_vat) { false }
+      let(:confirm_travel_expenditure) { false }
+
+      it 'does not persist the case details' do
+        expect { save }.not_to change { application.reload.attributes }
+          .from(
+            hash_including(
+              'confirm_excluding_vat' => nil,
+              'confirm_travel_expenditure' => nil,
+            )
+          )
+      end
+    end
+
+    context 'with nil confirmations' do
+      let(:confirm_excluding_vat) { nil }
+      let(:confirm_travel_expenditure) { nil }
+
+      it 'does not persist the case details' do
+        expect { save }.not_to change { application.reload.attributes }
+          .from(
+            hash_including(
+              'confirm_excluding_vat' => nil,
+              'confirm_travel_expenditure' => nil,
+            )
+          )
+      end
+    end
+  end
+end

--- a/spec/presenters/prior_authority/check_answers/primary_quote_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/primary_quote_card_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PriorAuthority::CheckAnswers::PrimaryQuoteCard do
           },
           {
             head_key: 'quote_upload',
-            text: 'TODO',
+            text: 'test.png',
           },
           {
             head_key: 'prior_authority_granted',

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         client_name: 'bob jim',
         prior_authority_granted: false,
         no_alternative_quote_reason: 'a reason',
+        confirm_excluding_vat: true,
+        confirm_travel_expenditure: true,
         defendant: {
           first_name: 'bob',
           last_name: 'jim',
@@ -107,7 +109,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
     }
   end
   let(:provider) { create(:provider) }
-  let(:application) { create(:prior_authority_application, :full) }
+  let(:application) { create(:prior_authority_application, :full, :with_confirmations) }
   let(:fixed_arbitrary_date) { Date.new(2024, 1, 15) }
 
   before { travel_to(fixed_arbitrary_date) }

--- a/spec/system/prior_authority/check_your_answers/no_prison_law_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/no_prison_law_spec.rb
@@ -149,10 +149,9 @@ RSpec.describe 'Prior authority applications, no prison law - check your answers
       expect(page)
         .to have_css('.govuk-summary-card__content', text: 'Service requiredMeteorologist')
         .and have_css('.govuk-summary-card__content', text: 'Service detailsJoe BloggsLAA, CR0 1RE')
-        .and have_css('.govuk-summary-card__content', text: 'Quote uploadTODO')
+        .and have_css('.govuk-summary-card__content', text: 'Quote uploadtest.png')
         .and have_css('.govuk-summary-card__content', text: 'Existing prior authority grantedYes')
         .and have_css('.govuk-summary-card__content', text: 'Why travel costs are requiredClient lives in Wales')
-      # TODO: quote sumary
 
       click_on 'Change'
       expect(page).to have_title('Primary quote summary')

--- a/spec/system/prior_authority/check_your_answers/prison_law_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/prison_law_spec.rb
@@ -1,0 +1,29 @@
+require 'system_helper'
+
+# NOTE: see non_prison_law_spec system test for main flow. This only checks the differences.
+#
+RSpec.describe 'Prior authority applications, prison law - check your answers' do
+  before do
+    fill_in_until_step(:submit_application, prison_law: 'Yes')
+    click_on 'Submit application'
+  end
+
+  it 'shows the Case and hearing details card and continues to check your answers' do
+    within('.govuk-summary-card', text: 'Case and hearing details') do
+      expect(page)
+        .to have_css('.govuk-summary-card__content', text: 'Date of next hearingNot known')
+
+      click_on 'Change'
+      expect(page).to have_title('Case and hearing details')
+    end
+
+    click_on 'Save and continue'
+    expect(page).to have_title('Check your answers')
+  end
+
+  it 'does NOT show the Case details and Hearing details cards' do
+    expect(page)
+      .to have_no_css('.govuk-summary-card', text: 'Case details')
+      .and have_no_css('.govuk-summary-card', text: 'Hearing details')
+  end
+end

--- a/spec/system/prior_authority/check_your_answers/submission_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/submission_spec.rb
@@ -44,4 +44,29 @@ RSpec.describe 'Prior authority applications, check your answers, submission' do
         .and have_css('.govuk-error-message', text: 'Select if you confirm that', count: 2)
     end
   end
+
+  context 'when check answers form already submitted' do
+    before do
+      check 'I confirm that all costs are exclusive of VAT'
+      check 'I confirm that any travel expenditure (such as mileage, ' \
+            'parking and travel fares) is included as additional items ' \
+            'in the primary quote, and is not included as part of any hourly rate'
+
+      click_on 'Accept and send'
+    end
+
+    it 'can be seen on the list of submitted applications' do
+      visit prior_authority_applications_path(anchor: 'submitted')
+
+      expect(page).to have_title('Your applications')
+      expect(page).to have_css('.govuk-table__row', text: '111111/123')
+    end
+
+    it 'stops me getting back to the check your answers page' do
+      application = PriorAuthorityApplication.find_by(ufn: '111111/123')
+      visit prior_authority_steps_check_answers_path(application)
+
+      expect(page).to have_title('Your application progress')
+    end
+  end
 end

--- a/spec/system/prior_authority/check_your_answers/submission_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/submission_spec.rb
@@ -1,0 +1,47 @@
+require 'system_helper'
+
+RSpec.describe 'Prior authority applications, check your answers, submission' do
+  before do
+    fill_in_until_step(:submit_application)
+    click_on 'Submit application'
+  end
+
+  it 'has the expected content relating to submission' do
+    expect(page).to have_title('Check your answers')
+
+    expect(page)
+      .to have_css('.govuk-heading-l', text: 'Now send your application')
+      .and have_css(
+        '.govuk-body',
+        text: 'By submitting this application you are confirming that, ' \
+              'to the best of your knowledge, the details you are providing are correct.'
+      )
+  end
+
+  it 'allows me to save and come back later' do
+    click_on 'Save and come back later'
+
+    expect(page).to have_title('Your applications')
+  end
+
+  context 'when I have confirmed conditions I must abide by' do
+    it 'allows me to submit my application' do
+      check 'I confirm that all costs are exclusive of VAT'
+      check 'I confirm that any travel expenditure (such as mileage, ' \
+            'parking and travel fares) is included as additional items ' \
+            'in the primary quote, and is not included as part of any hourly rate'
+
+      click_on 'Accept and send'
+      expect(page).to have_title('Application complete')
+    end
+  end
+
+  context 'when I have NOT confirmed conditions I must abide by' do
+    it 'warns me to confirm the conditions' do
+      click_on 'Accept and send'
+      expect(page).to have_title('Check your answers')
+        .and have_css('.govuk-error-summary', text: 'There is a problem on this page')
+        .and have_css('.govuk-error-message', text: 'Select if you confirm that', count: 2)
+    end
+  end
+end

--- a/spec/system/prior_authority/primary_quote_spec.rb
+++ b/spec/system/prior_authority/primary_quote_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
       fill_in 'Contact full name', with: 'Joe Bloggs'
       fill_in 'Organisation', with: 'LAA'
       fill_in 'Postcode', with: 'CR0 1RE'
-      page.attach_file(Rails.root.join('spec/fixtures/files/test.png').to_s) do
+      page.attach_file(file_fixture('test.png')) do
         page.find('.govuk-file-upload').click
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
     fill_in_until_step(:primary_quote)
     click_on 'Primary quote'
 
-    page.attach_file(Rails.root.join('spec/fixtures/files/test.png').to_s) do
+    page.attach_file(file_fixture('test.png')) do
       page.find('.govuk-file-upload').click
     end
 

--- a/spec/system/support/prior_authority/step_helpers.rb
+++ b/spec/system/support/prior_authority/step_helpers.rb
@@ -6,7 +6,7 @@ module PriorAuthority
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/AbcSize
-    def fill_in_until_step(step, prison_law: 'No', court_type: "Magistrates' court")
+    def fill_in_until_step(step, prison_law: 'No', client_detained: 'No', court_type: "Magistrates' court")
       fill_in_prison_law_and_authority_value(prison_law)
 
       return if step == :ufn
@@ -29,7 +29,7 @@ module PriorAuthority
       if prison_law == 'Yes'
         fill_in_next_hearing
       else
-        fill_in_case_detail
+        fill_in_case_detail(client_detained:)
 
         return if step == :hearing_detail
 
@@ -52,7 +52,7 @@ module PriorAuthority
       return if step.in?(%i[primary_quote_summary travel_cost])
 
       within('#travel-cost-summary') { click_on 'Change' }
-      fill_in_travel_cost
+      fill_in_travel_cost(prison_law:, client_detained:)
       click_on 'Save and continue'
 
       return if step == :alternative_quote_question
@@ -114,7 +114,7 @@ module PriorAuthority
       click_on 'Save and continue'
     end
 
-    def fill_in_case_detail
+    def fill_in_case_detail(client_detained: 'No', client_detained_prison: '')
       fill_in 'What was the main offence', with: 'Supply a controlled drug of Class A - Heroin'
 
       within('.govuk-form-group', text: 'Date of representation order') do
@@ -125,7 +125,8 @@ module PriorAuthority
 
       fill_in 'MAAT number', with: '123456'
       within('.govuk-form-group', text: 'Is your client detained?') do
-        choose 'No'
+        choose client_detained
+        fill_in 'Where is your client detained?', with: client_detained_prison if client_detained == 'Yes'
       end
 
       within('.govuk-form-group', text: 'Is this case subject to POCA (Proceeds of Crime Act 2002)?') do
@@ -174,8 +175,11 @@ module PriorAuthority
       click_on 'Save and continue'
     end
 
-    def fill_in_travel_cost
-      fill_in 'Why are there travel costs if your client is not detained?', with: 'Client lives in Wales'
+    def fill_in_travel_cost(prison_law: 'No', client_detained: 'No')
+      if prison_law == 'No' && client_detained == 'No'
+        fill_in 'Why are there travel costs if your client is not detained?', with: 'Client lives in Wales'
+      end
+
       fill_in 'Hours', with: 0
       fill_in 'Minutes', with: 30
       fill_in 'Hourly cost', with: 3.21

--- a/spec/system/support/prior_authority/step_helpers.rb
+++ b/spec/system/support/prior_authority/step_helpers.rb
@@ -170,7 +170,7 @@ module PriorAuthority
       fill_in 'Organisation', with: 'LAA'
       fill_in 'Postcode', with: 'CR0 1RE'
 
-      attach_file(Rails.root.join('spec/fixtures/files/test.png'))
+      attach_file(file_fixture('test.png'))
 
       click_on 'Save and continue'
     end


### PR DESCRIPTION
## Description of change
Add confirmations to check your answers page

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1132)

This adds the confirmations that must be accepted by the provider before they submit the application. Once accepted and form submitted the application is updated to the submitted status and the check you answers page, and all other editable form pages, can no longer be reached, preventing double submission or post submission data updates.

## Screenshots of changes (if applicable)

### Errors
![Screenshot 2024-02-16 at 09 32 33](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/7016425/1cfa0047-cc1a-4fa3-bd35-80ea52a8737a)

### Submission confirmation
![Screenshot 2024-02-16 at 11 41 22](https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/7016425/ee27ab19-3e46-4b28-b849-daf088c3ac1d)

