### PR TITLE
CRM457-979: Add index to alt quote card

### DIFF
--- a/app/presenters/prior_authority/check_answers/alternative_quotes_card.rb
+++ b/app/presenters/prior_authority/check_answers/alternative_quotes_card.rb
@@ -32,12 +32,12 @@ module PriorAuthority
         end
       end
 
-      # TODO: could use index to supply to translations?!
       def alternative_quote_collection
-        alternative_quotes.each_with_object([]) do |alt, memo|
+        alternative_quotes.each_with_object([]).with_index do |(quote, memo), idx|
           memo << {
             head_key: 'quote_summary',
-            text: alternative_quote_summary_html(alt),
+            head_opts: { count: idx + 1 },
+            text: alternative_quote_summary_html(quote),
           }
           memo
         end

--- a/config/locales/en/prior_authority/check_answers.yml
+++ b/config/locales/en/prior_authority/check_answers.yml
@@ -8,7 +8,7 @@ en:
           heading: Check your answers
           sections:
             alternative_quotes:
-              quote_summary: Quote
+              quote_summary: "Quote %{count}"
               no_alternatve_quotes: Reason for no alternative quotes
             case_contact:
               contact_details: Contact details

--- a/spec/presenters/prior_authority/check_answers/alternative_quotes_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/alternative_quotes_card_spec.rb
@@ -43,10 +43,12 @@ RSpec.describe PriorAuthority::CheckAnswers::AlternativeQuotesCard do
           [
             {
               head_key: 'quote_summary',
+              head_opts: { count: 1 },
               text: 'Jim Bob<br>£50.00'
             },
             {
               head_key: 'quote_summary',
+              head_opts: { count: 2 },
               text: 'John Boy<br>£100.00'
             },
           ]

--- a/spec/system/prior_authority/check_your_answers/no_prison_law_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/no_prison_law_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe 'Prior authority applications, no prison law - check your answers
   it 'shows the alternative quote card' do
     within('.govuk-summary-card', text: 'Alternative quotes') do
       expect(page)
-        .to have_css('.govuk-summary-card__content', text: 'QuoteJim Bob£155.00')
+        .to have_css('.govuk-summary-card__content', text: 'Quote 1Jim Bob£155.00')
 
       click_on 'Change'
       expect(page).to have_title('You\'ve added 1 alternative quote')


### PR DESCRIPTION
## Description of change
Add index number (1 based) to quote row in alternative quotes summary card of CYA page

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-979)

The prototype numbers the alternate quotes output on the CYA page.

## Screenshots of changes (if applicable)
<img width="1034" alt="Screenshot 2024-02-16 at 19 20 59" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/7016425/cfbb8e34-8d04-4677-afe2-43c5f880f0a6">
