### PR TITLE
CRM457-979: Move `actions` header resposibility to cards and add row actions capability

### DIFF
--- a/app/presenters/nsm/check_answers/report.rb
+++ b/app/presenters/nsm/check_answers/report.rb
@@ -90,7 +90,7 @@ module Nsm
         helper = Rails.application.routes.url_helpers
         [
           govuk_link_to(
-            'Change',
+            I18n.t('generic.change'),
             helper.url_for(controller: "nsm/steps/#{key}", action: :edit, id: claim.id, only_path: true)
           ),
         ]

--- a/app/presenters/prior_authority/check_answers/base.rb
+++ b/app/presenters/prior_authority/check_answers/base.rb
@@ -3,6 +3,9 @@ module PriorAuthority
   module CheckAnswers
     class Base
       include LaaMultiStepForms::CheckMissingHelper
+      include ActionView::Helpers::UrlHelper
+      include GovukLinkHelper
+      include GovukVisuallyHiddenHelper
       include ActionView::Helpers::TagHelper
 
       attr_accessor :group, :section
@@ -19,7 +22,7 @@ module PriorAuthority
 
       def rows
         row_data.map do |row|
-          row_content(row[:head_key], row[:text], row[:head_opts] || {})
+          row_content(row[:head_key], row[:text], row[:actions], row[:head_opts] || {})
         end
       end
 
@@ -33,7 +36,7 @@ module PriorAuthority
       end
       # :nocov:
 
-      def row_content(head_key, text, head_opts = {})
+      def row_content(head_key, text, actions = [], head_opts = {})
         heading = translate_table_key(section, head_key, **head_opts)
 
         {
@@ -43,8 +46,23 @@ module PriorAuthority
           },
           value: {
             text:
-          }
+          },
+          actions: actions
         }
+      end
+
+      def actions
+        helper = Rails.application.routes.url_helpers
+
+        [
+          govuk_link_to(
+            'Change',
+            helper.url_for(controller: "prior_authority/steps/#{section}",
+                           action: request_method,
+                           application_id: application.id,
+                           only_path: true)
+          ),
+        ]
       end
     end
   end

--- a/app/presenters/prior_authority/check_answers/base.rb
+++ b/app/presenters/prior_authority/check_answers/base.rb
@@ -56,7 +56,7 @@ module PriorAuthority
 
         [
           govuk_link_to(
-            'Change',
+            I18n.t('generic.change'),
             helper.url_for(controller: "prior_authority/steps/#{section}",
                            action: request_method,
                            application_id: application.id,

--- a/app/presenters/prior_authority/check_answers/primary_quote_card.rb
+++ b/app/presenters/prior_authority/check_answers/primary_quote_card.rb
@@ -100,7 +100,7 @@ module PriorAuthority
         [
           {
             head_key: 'summary',
-            text: PrimaryQuoteCardSummary.new(application).render
+            text: PrimaryQuoteCardSummary.new(application).render,
           },
         ]
       end

--- a/app/presenters/prior_authority/check_answers/report.rb
+++ b/app/presenters/prior_authority/check_answers/report.rb
@@ -1,10 +1,6 @@
 module PriorAuthority
   module CheckAnswers
     class Report
-      include GovukLinkHelper
-      include GovukVisuallyHiddenHelper
-      include ActionView::Helpers::UrlHelper
-
       GROUPS = %w[
         application_detail
         contact_details
@@ -27,18 +23,18 @@ module PriorAuthority
       def section_group(name, section_list)
         {
           heading: group_heading(name),
-          sections: sections(section_list)
+          sections: sections(section_list),
         }
       end
 
       def sections(section_list)
-        section_list.map do |data|
+        section_list.map do |section|
           {
             card: {
-              title: data.title,
-              actions: actions(data.section, request_method: data.request_method)
+              title: section.title,
+              actions: section.actions,
             },
-            rows: data.rows
+            rows: section.rows,
           }
         end
       end
@@ -80,20 +76,6 @@ module PriorAuthority
       end
 
       private
-
-      def actions(key, request_method: :edit)
-        helper = Rails.application.routes.url_helpers
-
-        [
-          govuk_link_to(
-            'Change',
-            helper.url_for(controller: "prior_authority/steps/#{key}",
-                           action: request_method,
-                           application_id: application.id,
-                           only_path: true)
-          ),
-        ]
-      end
 
       def group_heading(group_key, **)
         I18n.t("prior_authority.steps.check_answers.groups.#{group_key}.heading", **)

--- a/app/presenters/prior_authority/check_answers/ufn_card.rb
+++ b/app/presenters/prior_authority/check_answers/ufn_card.rb
@@ -30,10 +30,29 @@ module PriorAuthority
           {
             head_key: 'ufn',
             text: application.ufn,
+            actions: ufn_change_link,
           },
         ]
       end
       # rubocop:enable Metrics/MethodLength
+
+      def actions
+        []
+      end
+
+      def ufn_change_link
+        helper = Rails.application.routes.url_helpers
+
+        [
+          {
+            href:  helper.url_for(controller: "prior_authority/steps/#{section}",
+                                  action: request_method,
+                                  application_id: application.id,
+                                  only_path: true),
+            visually_hidden_text: 'Change Unique file number',
+          }
+        ]
+      end
     end
   end
 end

--- a/config/locales/en/generic.yml
+++ b/config/locales/en/generic.yml
@@ -5,4 +5,5 @@ en:
     'no': 'No'
     'true': "Yes"
     'false': "No"
+    change: Change
     unknown: Not known

--- a/spec/presenters/prior_authority/check_answers/ufn_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/ufn_card_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe PriorAuthority::CheckAnswers::UfnCard do
 
   describe '#row_data' do
     let(:application) do
-      build(:prior_authority_application,
-            laa_reference: 'LAA-u2u2u2',
-            prison_law: false,
-            ufn: '111111/111')
+      build_stubbed(
+        :prior_authority_application,
+        laa_reference: 'LAA-u2u2u2',
+        prison_law: false,
+        ufn: '111111/111'
+      )
     end
 
     it 'generates expected rows' do
@@ -34,7 +36,13 @@ RSpec.describe PriorAuthority::CheckAnswers::UfnCard do
           },
           {
             head_key: 'ufn',
-            text: '111111/111'
+            text: '111111/111',
+            actions: [
+              {
+                href: "/prior-authority/applications/#{application.id}/steps/ufn",
+                visually_hidden_text: 'Change Unique file number'
+              }
+            ],
           },
         ]
       )


### PR DESCRIPTION
## Description of change
Refactor CYA report and card objects and enable row actions

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-979)

The Change action links in the card "header" are the responsibility
of the individual card objects rather than the report object.

One card, Application details, should not have this link on
the header but on the Ufn row instead, according to designs
and, by moving the responsibility to the card object, this
becomes easy.

In addition, the govuk_summary_list accepts an ` actions:` key
on the individual rows so we use this to add a link to a specifc
row (UFN).

### Before changes:

<img width="1025" alt="Screenshot 2024-02-17 at 18 28 22" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/7016425/a2cfb93c-a92b-43c6-bcb4-a93068239aa4">


### After changes:

<img width="1051" alt="Screenshot 2024-02-17 at 18 27 39" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/7016425/6da9d13a-c228-4482-b51f-4e2a21113cf9">
