### PR TITLE
CRM457-979: Do not display travel cost reason on CYA for prison law matters

### DIFF
--- a/app/presenters/prior_authority/check_answers/primary_quote_card.rb
+++ b/app/presenters/prior_authority/check_answers/primary_quote_card.rb
@@ -3,16 +3,23 @@
 module PriorAuthority
   module CheckAnswers
     class PrimaryQuoteCard < Base
-      attr_reader :application, :service_cost_form
+      attr_reader :application, :service_cost_form, :travel_detail_form
 
       def initialize(application)
         @group = 'about_request'
         @section = 'primary_quote_summary'
         @application = application
+
         @service_cost_form = PriorAuthority::Steps::ServiceCostForm.build(
           application.primary_quote,
           application:
         )
+
+        @travel_detail_form = PriorAuthority::Steps::TravelDetailForm.build(
+          application.primary_quote,
+          application:
+        )
+
         super()
       end
 
@@ -92,7 +99,7 @@ module PriorAuthority
       end
 
       def travel_cost_reason
-        return [] if application.client_detained?
+        return [] unless travel_detail_form.travel_costs_require_justification?
 
         [
           {

--- a/spec/presenters/prior_authority/check_answers/primary_quote_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/primary_quote_card_spec.rb
@@ -195,10 +195,11 @@ RSpec.describe PriorAuthority::CheckAnswers::PrimaryQuoteCard do
       end
     end
 
-    context 'when client NOT detained' do
+    context 'when travel costs require justification (not prison law, client not detained)' do
       let(:application) do
         build(
           :prior_authority_application,
+          prison_law: false,
           client_detained: false,
           service_type: 'telecommunications_expert',
           primary_quote: primary_quote,
@@ -217,6 +218,26 @@ RSpec.describe PriorAuthority::CheckAnswers::PrimaryQuoteCard do
               text: 'client lives in northern ireland',
             },
           )
+      end
+    end
+
+    context 'when travel costs do NOT require justification (prison law)' do
+      let(:application) do
+        build(
+          :prior_authority_application,
+          prison_law: true,
+          client_detained: nil,
+          service_type: 'telecommunications_expert',
+          primary_quote: primary_quote,
+        )
+      end
+
+      let(:primary_quote) do
+        build(:quote, :primary, travel_cost_reason: nil)
+      end
+
+      it 'does NOT include travel cost reason row' do
+        expect(card.row_data.pluck(:head_key)).not_to include('travel_cost_reason')
       end
     end
   end


### PR DESCRIPTION

## Description of change
Do not display travel cost reason on CYA for prison law matters

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-979)

Prison law matters do not required the provider to answer
the question of whether the client is detained nor provide
a reason for travel if they are not detained.
